### PR TITLE
初期プロジェクト構造の追加

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags: 'v[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  GOPROXY: https://proxy.golang.org
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,57 @@
+name: Tests
+on: [push, pull_request]
+env:
+  GOPROXY: https://proxy.golang.org
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Setup tools
+        run: | 
+          cd v2
+          make tools
+
+      - name: make lint
+        run:  |
+          cd v2
+          make lint
+
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Setup tools
+        run: | 
+          cd v2
+          make tools
+
+      - name: make test
+        run: |
+          cd v2
+          make test

--- a/.github/workflows/textlint.yaml
+++ b/.github/workflows/textlint.yaml
@@ -1,0 +1,21 @@
+name: Textlint
+on: [push, pull_request]
+jobs:
+  lint:
+    name: textlint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        working-directory:
+          - '.'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: lint a document with textlint
+        uses: sacloud/textlint-action@v0.0.1
+        with:
+          working-directory: ${{ matrix.working-directory }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+vendor/
+dist/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+run:
+  deadline: 10m10s
+
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+#    - interfacer
+    - nakedret
+    - misspell
+    - revive
+#    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - unconvert
+    - varcheck
+    - vet
+    - vetshadow
+    - whitespace

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,6 @@
+build:
+  skip: true
+release:
+  draft: false
+changelog:
+  skip: false

--- a/.textlintignore
+++ b/.textlintignore
@@ -1,0 +1,2 @@
+LICENSE
+dist/

--- a/.textlintrc
+++ b/.textlintrc
@@ -1,0 +1,23 @@
+{
+  "rules": {
+    "common-misspellings": true,
+    "preset-jtf-style": {
+      "3.1.1.全角文字と半角文字の間": false,
+      "4.2.7.コロン(：)":false,
+      "4.3.1.丸かっこ（）": false
+    },
+    "preset-ja-technical-writing": {
+      "ja-no-mixed-period": false,
+      "no-exclamation-question-mark": false,
+      "sentence-length": {
+        max:150
+      },
+      "max-kanji-continuous-len": {
+        "max": 7
+      },
+      "max-comma": {
+        max: 4
+      }
+    }
+  }
+}

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+# This is the list of Libsacloud authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Kazumichi Yamamoto

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+AUTHOR          ?="The sacloud/iaas-api-go Authors"
+COPYRIGHT_YEAR  ?="2022"
+COPYRIGHT_FILES ?=$$(find . -name "*.go" -print | grep -v "/vendor/")
+
+default: gen fmt set-license go-licenses-check goimports lint test
+
+.PHONY: test
+test:
+	TESTACC= go test ./... $(TESTARGS) -v -timeout=120m -parallel=8 -race;
+
+.PHONY: testacc
+testacc:
+	TESTACC=1 go test ./... $(TESTARGS) --tags=acctest -v -timeout=120m -parallel=8 ;
+
+.PHONY: tools
+tools:
+	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/stringer@latest
+	go install github.com/sacloud/addlicense@latest
+	go install github.com/client9/misspell/cmd/misspell@latest
+	go install github.com/google/go-licenses@v1.0.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.44.2
+
+.PHONY: clean
+clean:
+	find . -type f -name "zz_*.go" -delete
+
+.PHONY: gen
+gen: _gen fmt goimports set-license
+
+.PHONY: _gen
+_gen:
+	go generate ./...
+
+.PHONY: goimports
+goimports: fmt
+	goimports -l -w .
+
+.PHONY: fmt
+fmt:
+	find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
+
+.PHONY: godoc
+godoc:
+	echo "URL: http://localhost:6060/pkg/github.com/sacloud/iaas-api-go/"
+	godoc -http=localhost:6060
+
+.PHONY: lint-all
+lint-all: lint-go lint-text
+
+.PHONY: lint lint-go
+lint: lint-go
+lint-go:
+	golangci-lint run ./...
+
+.PHONY: textlint lint-text
+textlint: lint-text
+lint-text:
+	@docker run -it --rm -v $$PWD:/work -w /work ghcr.io/sacloud/textlint-action:v0.0.1 .
+
+.PHONY: set-license
+set-license:
+	@addlicense -c $(AUTHOR) -y $(COPYRIGHT_YEAR) $(COPYRIGHT_FILES)
+
+.PHONY: go-licenses-check
+go-licenses-check:
+	go-licenses check .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # iaas-api-go
+
+Go言語向けのさくらのクラウドIaaS APIライブラリ
+
+## 概要
+
+:baby_symbol: iaas-api-goは設計/開発中です。  
+[sacloud/libsacloud v2](https://github.com/sacloud/libsacloud)の後継プロジェクトで、さくらのクラウド APIのうちのIaaS部分を担当します。
+
+:warning:  v1.0に達するまでは互換性のない形で変更される可能性がありますのでご注意ください。
+
+### 関連プロジェクト
+
+- [sacloud/sacloud-go](https://github.com/sacloud/sacloud-go): sacloud/iaas-api-goを用いた高レベルAPIライブラリ
+
+## License
+
+`sacloud/iaas-api-go` Copyright (C) 2022 [The sacloud/iaas-api-go Authors](AUTHORS).
+
+This project is published under [Apache 2.0 License](LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sacloud/iaas-api-go
+
+go 1.17

--- a/version.go
+++ b/version.go
@@ -1,0 +1,18 @@
+// Copyright 2022 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iaas
+
+// Version バージョン
+const Version = "0.0.1-dev"


### PR DESCRIPTION
libsacloud v2からプロジェクト構造のみを移行

- v0 or v1からになるためv2ディレクトリは廃止
- その他ソースコードの構成は未定なため最低限のファイルだけ移行
- MakefileやGitHub Actionsなどの追加