### PR TITLE
iaas.StateWaiterをsacloud-go/pkg/waitパッケージを使うように切り替え

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/sacloud/api-client-go v0.0.0-20220311054319-f37467272e84
 	github.com/sacloud/go-http v0.0.4
-	github.com/sacloud/sacloud-go/pkg v0.0.0-20220310002004-ab494c9c1c6d
+	github.com/sacloud/sacloud-go/pkg v0.0.0-20220314011406-ba5d40102e88
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 )

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,9 @@ github.com/sacloud/api-client-go v0.0.0-20220311054319-f37467272e84 h1:yhGNZLgxT
 github.com/sacloud/api-client-go v0.0.0-20220311054319-f37467272e84/go.mod h1:RvP4b31YdaVjXM/XQAvKAeTTs0vGdvfypvP/7ysWdAA=
 github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po=
 github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
-github.com/sacloud/sacloud-go/pkg v0.0.0-20220310002004-ab494c9c1c6d h1:Rdj8QU3EZrmdUKJMvJ0U3kkgUZFLzZ5u1kMKdQnW7eY=
 github.com/sacloud/sacloud-go/pkg v0.0.0-20220310002004-ab494c9c1c6d/go.mod h1:/hcfG/jZlqNDRpnMDl9rm1aBLgNCeX1NF6FyaIwk9+k=
+github.com/sacloud/sacloud-go/pkg v0.0.0-20220314011406-ba5d40102e88 h1:NMs24JU1/xKSTdfsjugJeXjYh9cbS4W/FaJIJK9PtcA=
+github.com/sacloud/sacloud-go/pkg v0.0.0-20220314011406-ba5d40102e88/go.mod h1:/hcfG/jZlqNDRpnMDl9rm1aBLgNCeX1NF6FyaIwk9+k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/helper/api/caller.go
+++ b/helper/api/caller.go
@@ -45,7 +45,7 @@ func newCaller(opts *CallerOptions) iaas.APICaller {
 
 	caller := iaas.NewClientWithOptions(opts.Options)
 
-	iaas.DefaultStatePollingTimeout = 72 * time.Hour
+	defaults.DefaultStatePollingTimeout = 72 * time.Hour
 
 	if opts.TraceAPI {
 		// note: exact once
@@ -84,12 +84,10 @@ func SetupFakeDefaults() {
 	defaultInterval := 10 * time.Millisecond
 
 	// update default polling intervals: libsacloud/sacloud
-	iaas.DefaultStatePollingInterval = defaultInterval
-	iaas.DefaultDBStatusPollingInterval = defaultInterval
+	defaults.DefaultStatePollingInterval = defaultInterval
+	defaults.DefaultDBStatusPollingInterval = defaultInterval
+
 	// update default polling intervals: libsacloud/helper/setup
-	defaults.DefaultDeleteWaitInterval = defaultInterval
-	defaults.DefaultProvisioningWaitInterval = defaultInterval
-	defaults.DefaultPollingInterval = defaultInterval
 	// update default polling intervals: libsacloud/helper/builder
 	defaults.DefaultNICUpdateWaitDuration = defaultInterval
 	// update default timeouts and span: libsacloud/helper/power

--- a/helper/defaults/defaults.go
+++ b/helper/defaults/defaults.go
@@ -18,22 +18,10 @@ import "time"
 
 // for setup package
 var (
-	// DefaultMaxRetryCount デフォルトリトライ最大数
-	DefaultMaxRetryCount = 3
-	// DefaultProvisioningRetryCount リソースごとのプロビジョニングAPI呼び出しのリトライ最大数
-	DefaultProvisioningRetryCount = 10
-
-	// DefaultProvisioningWaitInterval リソースごとのプロビジョニングAPI呼び出しのリトライ間隔
-	DefaultProvisioningWaitInterval = 5 * time.Second
-
-	// DefaultDeleteRetryCount リソースごとの削除API呼び出しのリトライ最大数
-	DefaultDeleteRetryCount = 10
-
-	// DefaultDeleteWaitInterval リソースごとの削除API呼び出しのリトライ間隔
-	DefaultDeleteWaitInterval = 10 * time.Second
-
-	// DefaultPollingInterval ポーリング処理の間隔
-	DefaultPollingInterval = 5 * time.Second
+	// DefaultStatePollingTimeout StatePollWaiterでのデフォルトタイムアウト
+	DefaultStatePollingTimeout = 20 * time.Minute
+	// DefaultStatePollingInterval StatePollWaiterでのデフォルトポーリング間隔
+	DefaultStatePollingInterval = 5 * time.Second
 
 	// DefaultPowerHelperBootRetrySpan helper/powerでの起動リクエストリトライ間隔
 	DefaultPowerHelperBootRetrySpan = 20 * time.Second
@@ -49,4 +37,10 @@ var (
 var (
 	// DefaultNICUpdateWaitDuration NIC切断/削除後の待ち時間デフォルト値
 	DefaultNICUpdateWaitDuration = 5 * time.Second
+)
+
+// for cleanup package
+var (
+	// DefaultDBStatusPollingInterval データベースアプライアンスのステータス確認ポーリングの間隔
+	DefaultDBStatusPollingInterval = 30 * time.Second
 )

--- a/helper/power/power.go
+++ b/helper/power/power.go
@@ -228,7 +228,7 @@ func boot(ctx context.Context, h handler) error {
 	inProcess := false
 
 	waiter := iaas.WaiterForUp(h.read)
-	compCh, progressCh, errCh := waiter.AsyncWaitForState(ctx)
+	compCh, progressCh, errCh := waiter.WaitForStateAsync(ctx)
 
 	var state interface{}
 
@@ -276,7 +276,7 @@ func shutdown(ctx context.Context, h handler, force bool) error {
 	inProcess := false
 
 	waiter := iaas.WaiterForDown(h.read)
-	compCh, progressCh, errCh := waiter.AsyncWaitForState(ctx)
+	compCh, progressCh, errCh := waiter.WaitForStateAsync(ctx)
 
 	var state interface{}
 

--- a/helper/power/power_test.go
+++ b/helper/power/power_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/defaults"
 	"github.com/sacloud/iaas-api-go/types"
 	"github.com/stretchr/testify/require"
 )
@@ -29,13 +30,13 @@ import (
 func TestPowerHandler(t *testing.T) {
 	t.Parallel()
 
-	defaultInterval := iaas.DefaultStatePollingInterval
+	defaultInterval := defaults.DefaultStatePollingInterval
 
-	iaas.DefaultStatePollingInterval = 10 * time.Millisecond
+	defaults.DefaultStatePollingInterval = 10 * time.Millisecond
 	BootRetrySpan = time.Millisecond
 	ShutdownRetrySpan = time.Millisecond
 	defer func() {
-		iaas.DefaultStatePollingInterval = defaultInterval
+		defaults.DefaultStatePollingInterval = defaultInterval
 		BootRetrySpan = 0
 		ShutdownRetrySpan = 0
 	}()

--- a/helper/wait/simple_state_waiter.go
+++ b/helper/wait/simple_state_waiter.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/pkg/wait"
 )
 
 // ByFunc デフォルトのパラメータでSimpleStateWaiterを作成して返す
-func ByFunc(readStateFunc ReadStateFunc) iaas.StateWaiter {
+func ByFunc(readStateFunc ReadStateFunc) wait.StateWaiter {
 	return &SimpleStateWaiter{ReadStateFunc: readStateFunc}
 }
 
@@ -44,7 +45,7 @@ type SimpleStateWaiter struct {
 	PollingInterval time.Duration
 }
 
-func (s *SimpleStateWaiter) waiter() iaas.StateWaiter {
+func (s *SimpleStateWaiter) waiter() wait.StateWaiter {
 	return &iaas.StatePollingWaiter{
 		ReadFunc: func() (interface{}, error) {
 			result, err := s.ReadStateFunc()
@@ -60,8 +61,8 @@ func (s *SimpleStateWaiter) waiter() iaas.StateWaiter {
 			types.Availabilities.Unknown,
 		},
 
-		PollingInterval: s.PollingInterval,
-		Timeout:         s.Timeout,
+		Interval: s.PollingInterval,
+		Timeout:  s.Timeout,
 	}
 }
 
@@ -70,19 +71,9 @@ func (s *SimpleStateWaiter) WaitForState(ctx context.Context) (interface{}, erro
 	return s.waiter().WaitForState(ctx)
 }
 
-// AsyncWaitForState iaas.StateWaiterの実装
-func (s *SimpleStateWaiter) AsyncWaitForState(ctx context.Context) (compCh <-chan interface{}, progressCh <-chan interface{}, errorCh <-chan error) {
-	return s.waiter().AsyncWaitForState(ctx)
-}
-
-// SetPollingTimeout iaas.StateWaiterの実装
-func (s *SimpleStateWaiter) SetPollingTimeout(d time.Duration) {
-	s.waiter().SetPollingTimeout(d)
-}
-
-// SetPollingInterval iaas.StateWaiterの実装
-func (s *SimpleStateWaiter) SetPollingInterval(d time.Duration) {
-	s.waiter().SetPollingInterval(d)
+// WaitForStateAsync iaas.StateWaiterの実装
+func (s *SimpleStateWaiter) WaitForStateAsync(ctx context.Context) (compCh <-chan interface{}, progressCh <-chan interface{}, errorCh <-chan error) {
+	return s.waiter().WaitForStateAsync(ctx)
 }
 
 type fakeState struct {

--- a/helper/wait/wait.go
+++ b/helper/wait/wait.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/defaults"
 	"github.com/sacloud/iaas-api-go/types"
 )
 
@@ -55,9 +56,9 @@ func UntilDatabaseIsUp(ctx context.Context, client iaas.DatabaseAPI, zone string
 	waiter := iaas.WaiterForUp(func() (interface{}, error) {
 		return client.Status(ctx, zone, id)
 	})
-	waiter.SetPollingInterval(iaas.DefaultDBStatusPollingInterval) // HACK 現状は決め打ち、ユースケースが出たら修正する
-	_, err = waiter.WaitForState(ctx)
+	waiter.(*iaas.StatePollingWaiter).Interval = defaults.DefaultDBStatusPollingInterval // HACK 現状は決め打ち、ユースケースが出たら修正する
 
+	_, err = waiter.WaitForState(ctx)
 	return database, err
 }
 

--- a/state_functions.go
+++ b/state_functions.go
@@ -14,10 +14,13 @@
 
 package iaas
 
-import "github.com/sacloud/iaas-api-go/types"
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/pkg/wait"
+)
 
 // WaiterForUp 起動完了まで待つためのStateWaiterを返す
-func WaiterForUp(readFunc StateReadFunc) StateWaiter {
+func WaiterForUp(readFunc wait.StateReadFunc) wait.StateWaiter {
 	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{
@@ -44,7 +47,7 @@ func WaiterForUp(readFunc StateReadFunc) StateWaiter {
 // WaiterForApplianceUp 起動完了まで待つためのStateWaiterを返す
 //
 // アプライアンス向けに404発生時のリトライを設定可能
-func WaiterForApplianceUp(readFunc StateReadFunc, notFoundRetry int) StateWaiter {
+func WaiterForApplianceUp(readFunc wait.StateReadFunc, notFoundRetry int) wait.StateWaiter {
 	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{
@@ -70,7 +73,7 @@ func WaiterForApplianceUp(readFunc StateReadFunc, notFoundRetry int) StateWaiter
 }
 
 // WaiterForDown シャットダウン完了まで待つためのStateWaiterを返す
-func WaiterForDown(readFunc StateReadFunc) StateWaiter {
+func WaiterForDown(readFunc wait.StateReadFunc) wait.StateWaiter {
 	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{
@@ -91,7 +94,7 @@ func WaiterForDown(readFunc StateReadFunc) StateWaiter {
 }
 
 // WaiterForReady リソースの利用準備完了まで待つためのStateWaiterを返す
-func WaiterForReady(readFunc StateReadFunc) StateWaiter {
+func WaiterForReady(readFunc wait.StateReadFunc) wait.StateWaiter {
 	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{

--- a/state_test.go
+++ b/state_test.go
@@ -46,9 +46,9 @@ func TestStatePollingWaiter_withStateCheckFunc(t *testing.T) {
 			ReadFunc: func() (interface{}, error) {
 				return &dummyState{}, nil
 			},
-			StateCheckFunc:  testStateCheckFunc,
-			Timeout:         5 * time.Millisecond,
-			PollingInterval: 1 * time.Millisecond,
+			StateCheckFunc: testStateCheckFunc,
+			Timeout:        5 * time.Millisecond,
+			Interval:       1 * time.Millisecond,
 		}
 		ctx := context.Background()
 		_, err := waiter.WaitForState(ctx)
@@ -61,9 +61,9 @@ func TestStatePollingWaiter_withStateCheckFunc(t *testing.T) {
 			ReadFunc: func() (interface{}, error) {
 				return &dummyState{}, nil
 			},
-			StateCheckFunc:  testStateCheckFunc,
-			Timeout:         100 * time.Millisecond,
-			PollingInterval: 1 * time.Millisecond,
+			StateCheckFunc: testStateCheckFunc,
+			Timeout:        100 * time.Millisecond,
+			Interval:       1 * time.Millisecond,
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -90,9 +90,9 @@ func TestStatePollingWaiter_withStateCheckFunc(t *testing.T) {
 				}
 				return &dummyState{state: "done"}, nil
 			},
-			StateCheckFunc:  testStateCheckFunc,
-			Timeout:         100 * time.Millisecond,
-			PollingInterval: 1 * time.Millisecond,
+			StateCheckFunc: testStateCheckFunc,
+			Timeout:        100 * time.Millisecond,
+			Interval:       1 * time.Millisecond,
 		}
 		ctx := context.Background()
 		_, err := waiter.WaitForState(ctx)
@@ -113,9 +113,9 @@ func TestStatePollingWaiter_withStateCheckFunc(t *testing.T) {
 				}
 				return &dummyState{state: "done"}, nil
 			},
-			StateCheckFunc:  testStateCheckFunc,
-			Timeout:         100 * time.Millisecond,
-			PollingInterval: 1 * time.Millisecond,
+			StateCheckFunc: testStateCheckFunc,
+			Timeout:        100 * time.Millisecond,
+			Interval:       1 * time.Millisecond,
 		}
 		ctx := context.Background()
 		_, err := waiter.WaitForState(ctx)
@@ -130,9 +130,9 @@ func TestStatePollingWaiter_withStateCheckFunc(t *testing.T) {
 			ReadFunc: func() (interface{}, error) {
 				return &dummyState{}, errors.New("dummy")
 			},
-			StateCheckFunc:  testStateCheckFunc,
-			Timeout:         100 * time.Millisecond,
-			PollingInterval: 1 * time.Millisecond,
+			StateCheckFunc: testStateCheckFunc,
+			Timeout:        100 * time.Millisecond,
+			Interval:       1 * time.Millisecond,
 		}
 		ctx := context.Background()
 		_, err := waiter.WaitForState(ctx)
@@ -176,7 +176,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 			},
 			TargetInstanceStatus: []types.EServerInstanceStatus{types.ServerInstanceStatuses.Up},
 			Timeout:              100 * time.Millisecond,
-			PollingInterval:      1 * time.Millisecond,
+			Interval:             1 * time.Millisecond,
 		}
 		ctx := context.Background()
 		_, err := waiter.WaitForState(ctx)
@@ -190,7 +190,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 			},
 			TargetInstanceStatus:       []types.EServerInstanceStatus{types.ServerInstanceStatuses.Up},
 			Timeout:                    100 * time.Millisecond,
-			PollingInterval:            1 * time.Millisecond,
+			Interval:                   1 * time.Millisecond,
 			RaiseErrorWithUnknownState: true,
 		}
 		ctx := context.Background()
@@ -214,7 +214,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 			},
 			TargetAvailability: []types.EAvailability{types.Availabilities.Available},
 			Timeout:            100 * time.Millisecond,
-			PollingInterval:    1 * time.Millisecond,
+			Interval:           1 * time.Millisecond,
 		}
 		ctx := context.Background()
 		_, err := waiter.WaitForState(ctx)
@@ -229,7 +229,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 			},
 			TargetAvailability:         []types.EAvailability{types.Availabilities.Available},
 			Timeout:                    100 * time.Millisecond,
-			PollingInterval:            1 * time.Millisecond,
+			Interval:                   1 * time.Millisecond,
 			RaiseErrorWithUnknownState: true,
 		}
 		ctx := context.Background()


### PR DESCRIPTION
https://github.com/sacloud/sacloud-go/pull/16 でsacloud-goに切り出したwaitパッケージを使うように修正

IaaS側固有事情として以下のような実装を残した。

- Availability/InstanceStatusによるステートのチェック
- リソース作成直後の404 NotFound対応