### PR TITLE
オートスケールAPI

### DIFF
--- a/customize_envelope.go
+++ b/customize_envelope.go
@@ -156,6 +156,16 @@ func (s autoBackupFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
+func (s autoScaleFindRequestEnvelope) MarshalJSON() ([]byte, error) {
+	type alias autoScaleFindRequestEnvelope
+	tmp := alias(s)
+	if tmp.Filter == nil {
+		tmp.Filter = search.Filter{}
+	}
+	tmp.Filter[search.Key("Provider.Class")] = "autoscale"
+	return json.Marshal(tmp)
+}
+
 func (s certificateAuthorityFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	type alias certificateAuthorityFindRequestEnvelope
 	tmp := alias(s)

--- a/fake/ops_auto_scale.go
+++ b/fake/ops_auto_scale.go
@@ -1,0 +1,112 @@
+// Copyright 2022 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// Find is fake implementation
+func (o *AutoScaleOp) Find(ctx context.Context, conditions *iaas.FindCondition) (*iaas.AutoScaleFindResult, error) {
+	results, _ := find(o.key, iaas.APIDefaultZone, conditions)
+	var values []*iaas.AutoScale
+	for _, res := range results {
+		dest := &iaas.AutoScale{}
+		copySameNameField(res, dest)
+		values = append(values, dest)
+	}
+	return &iaas.AutoScaleFindResult{
+		Total:     len(results),
+		Count:     len(results),
+		From:      0,
+		AutoScale: values,
+	}, nil
+}
+
+// Create is fake implementation
+func (o *AutoScaleOp) Create(ctx context.Context, param *iaas.AutoScaleCreateRequest) (*iaas.AutoScale, error) {
+	result := &iaas.AutoScale{}
+	copySameNameField(param, result)
+	fill(result, fillID, fillCreatedAt)
+	result.Availability = types.Availabilities.Available
+
+	// TODO core logic is not implemented
+
+	putAutoScale(iaas.APIDefaultZone, result)
+	return result, nil
+}
+
+// Read is fake implementation
+func (o *AutoScaleOp) Read(ctx context.Context, id types.ID) (*iaas.AutoScale, error) {
+	value := getAutoScaleByID(iaas.APIDefaultZone, id)
+	if value == nil {
+		return nil, newErrorNotFound(o.key, id)
+	}
+	dest := &iaas.AutoScale{}
+	copySameNameField(value, dest)
+	return dest, nil
+}
+
+// Update is fake implementation
+func (o *AutoScaleOp) Update(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateRequest) (*iaas.AutoScale, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putAutoScale(iaas.APIDefaultZone, value)
+	return value, nil
+}
+
+// UpdateSettings is fake implementation
+func (o *AutoScaleOp) UpdateSettings(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateSettingsRequest) (*iaas.AutoScale, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putAutoScale(iaas.APIDefaultZone, value)
+	return value, nil
+}
+
+// Delete is fake implementation
+func (o *AutoScaleOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	ds().Delete(o.key, iaas.APIDefaultZone, id)
+	return nil
+}
+
+func (o *AutoScaleOp) Status(ctx context.Context, id types.ID) (*iaas.AutoScaleStatus, error) {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &iaas.AutoScaleStatus{
+		LatestLogs:    []string{"log1", "log2"},
+		ResourcesText: "...",
+	}, nil
+}

--- a/fake/zz_api_ops.go
+++ b/fake/zz_api_ops.go
@@ -41,6 +41,9 @@ func switchFactoryFuncToFake() {
 	iaas.SetClientFactoryFunc(ResourceAutoBackup, func(caller iaas.APICaller) interface{} {
 		return NewAutoBackupOp()
 	})
+	iaas.SetClientFactoryFunc(ResourceAutoScale, func(caller iaas.APICaller) interface{} {
+		return NewAutoScaleOp()
+	})
 	iaas.SetClientFactoryFunc(ResourceBill, func(caller iaas.APICaller) interface{} {
 		return NewBillOp()
 	})
@@ -214,6 +217,22 @@ type AutoBackupOp struct {
 func NewAutoBackupOp() iaas.AutoBackupAPI {
 	return &AutoBackupOp{
 		key: ResourceAutoBackup,
+	}
+}
+
+/*************************************************
+* AutoScaleOp
+*************************************************/
+
+// AutoScaleOp is fake implementation of AutoScaleAPI interface
+type AutoScaleOp struct {
+	key string
+}
+
+// NewAutoScaleOp creates new AutoScaleOp instance
+func NewAutoScaleOp() iaas.AutoScaleAPI {
+	return &AutoScaleOp{
+		key: ResourceAutoScale,
 	}
 }
 

--- a/fake/zz_api_ops_test.go
+++ b/fake/zz_api_ops_test.go
@@ -36,6 +36,10 @@ func TestResourceOps(t *testing.T) {
 		t.Fatalf("%s is not iaas.AutoBackup", op)
 	}
 
+	if op, ok := NewAutoScaleOp().(iaas.AutoScaleAPI); !ok {
+		t.Fatalf("%s is not iaas.AutoScale", op)
+	}
+
 	if op, ok := NewBillOp().(iaas.BillAPI); !ok {
 		t.Fatalf("%s is not iaas.Bill", op)
 	}

--- a/fake/zz_resources.go
+++ b/fake/zz_resources.go
@@ -23,6 +23,8 @@ const (
 	ResourceAuthStatus = "AuthStatus"
 	// ResourceAutoBackup is resource key of fake store
 	ResourceAutoBackup = "AutoBackup"
+	// ResourceAutoScale is resource key of fake store
+	ResourceAutoScale = "AutoScale"
 	// ResourceBill is resource key of fake store
 	ResourceBill = "Bill"
 	// ResourceBridge is resource key of fake store

--- a/fake/zz_store.go
+++ b/fake/zz_store.go
@@ -106,6 +106,34 @@ func putAutoBackup(zone string, value *iaas.AutoBackup) {
 	ds().Put(ResourceAutoBackup, zone, 0, value)
 }
 
+func getAutoScale(zone string) []*iaas.AutoScale {
+	values := ds().List(ResourceAutoScale, zone)
+	var ret []*iaas.AutoScale
+	for _, v := range values {
+		if v, ok := v.(*iaas.AutoScale); ok {
+			ret = append(ret, v)
+		}
+	}
+	return ret
+}
+
+func getAutoScaleByID(zone string, id types.ID) *iaas.AutoScale {
+	v := ds().Get(ResourceAutoScale, zone, id)
+	if v, ok := v.(*iaas.AutoScale); ok {
+		return v
+	}
+	return nil
+}
+
+func putAutoScale(zone string, value *iaas.AutoScale) {
+	var v interface{} = value
+	if id, ok := v.(accessor.ID); ok {
+		ds().Put(ResourceAutoScale, zone, id.GetID(), value)
+		return
+	}
+	ds().Put(ResourceAutoScale, zone, 0, value)
+}
+
 func getBill(zone string) []*iaas.Bill {
 	values := ds().List(ResourceBill, zone)
 	var ret []*iaas.Bill

--- a/internal/define/apis.go
+++ b/internal/define/apis.go
@@ -36,6 +36,7 @@ func init() {
 	APIs.Define(archiveAPI)              // アーカイブ
 	APIs.Define(authStatusAPI)           // 認証情報
 	APIs.Define(autoBackupAPI)           // 自動バックアップ
+	APIs.Define(autoScaleAPI)            // オートスケール
 	APIs.Define(billAPI)                 // 請求情報
 	APIs.Define(bridgeAPI)               // ブリッジ
 	APIs.Define(cdromAPI)                // ISOイメージ(CD-ROM)

--- a/internal/define/auto_scale.go
+++ b/internal/define/auto_scale.go
@@ -1,0 +1,196 @@
+// Copyright 2022 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package define
+
+import (
+	"net/http"
+
+	"github.com/sacloud/iaas-api-go/internal/define/names"
+	"github.com/sacloud/iaas-api-go/internal/define/ops"
+	"github.com/sacloud/iaas-api-go/internal/dsl"
+	"github.com/sacloud/iaas-api-go/internal/dsl/meta"
+	"github.com/sacloud/iaas-api-go/naked"
+)
+
+const (
+	autoScaleAPIName     = "AutoScale"
+	autoScaleAPIPathName = "commonserviceitem"
+)
+
+var autoScaleAPI = &dsl.Resource{
+	Name:       autoScaleAPIName,
+	PathName:   autoScaleAPIPathName,
+	PathSuffix: dsl.CloudAPISuffix,
+	IsGlobal:   true,
+	Operations: dsl.Operations{
+		// find
+		ops.FindCommonServiceItem(autoScaleAPIName, autoScaleNakedType, findParameter, autoScaleView),
+
+		// create
+		ops.CreateCommonServiceItem(autoScaleAPIName, autoScaleNakedType, autoScaleCreateParam, autoScaleView),
+
+		// read
+		ops.ReadCommonServiceItem(autoScaleAPIName, autoScaleNakedType, autoScaleView),
+
+		// update
+		ops.UpdateCommonServiceItem(autoScaleAPIName, autoScaleNakedType, autoScaleUpdateParam, autoScaleView),
+		// updateSettings
+		ops.UpdateCommonServiceItemSettings(autoScaleAPIName, autoScaleUpdateSettingsNakedType, autoScaleUpdateSettingsParam, autoScaleView),
+
+		// delete
+		ops.Delete(autoScaleAPIName),
+
+		// status
+		{
+			ResourceName: autoScaleAPIName,
+			Name:         "Status",
+			PathFormat:   dsl.DefaultPathFormatWithID + "/autoscale/status",
+			Method:       http.MethodGet,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Type: meta.Static(naked.AutoScaleRunningStatus{}),
+				Name: "AutoScale",
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "AutoScale",
+					DestField:   autoScaleStatusView.Name,
+					IsPlural:    false,
+					Model:       autoScaleStatusView,
+				},
+			},
+		},
+	},
+}
+
+var (
+	autoScaleNakedType               = meta.Static(naked.AutoScale{})
+	autoScaleUpdateSettingsNakedType = meta.Static(naked.AutoScaleSettingsUpdate{})
+
+	autoScaleView = &dsl.Model{
+		Name:      autoScaleAPIName,
+		NakedType: autoScaleNakedType,
+		Fields: []*dsl.FieldDesc{
+			fields.ID(),
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.Availability(),
+			fields.IconID(),
+			fields.CreatedAt(),
+			fields.ModifiedAt(),
+
+			// settings
+			fields.AutoScaleZones(),
+			fields.AutoScaleConfig(),
+			fields.AutoScaleServerPrefix(),
+			fields.AutoScaleCPUThresholdUp(),
+			fields.AutoScaleCPUThresholdDown(),
+			fields.SettingsHash(),
+
+			// status
+			fields.AutoScaleAPIKeyID(),
+		},
+	}
+
+	autoScaleCreateParam = &dsl.Model{
+		Name:      names.CreateParameterName(autoScaleAPIName),
+		NakedType: autoScaleNakedType,
+		ConstFields: []*dsl.ConstFieldDesc{
+			{
+				Name: "Class",
+				Type: meta.TypeString,
+				Tags: &dsl.FieldTags{
+					MapConv: "Provider.Class",
+				},
+				Value: `"autoscale"`,
+			},
+			{
+				Name:  "ServiceClass",
+				Type:  meta.TypeString,
+				Value: `"cloud/autoscale/1"`,
+			},
+		},
+		Fields: []*dsl.FieldDesc{
+			// common fields
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.IconID(),
+
+			// settings
+			fields.AutoScaleZones(),
+			fields.AutoScaleConfig(),
+			fields.AutoScaleServerPrefix(),
+			fields.AutoScaleCPUThresholdUp(),
+			fields.AutoScaleCPUThresholdDown(),
+			// status
+			fields.AutoScaleAPIKeyID(),
+		},
+	}
+
+	autoScaleUpdateParam = &dsl.Model{
+		Name:      names.UpdateParameterName(autoScaleAPIName),
+		NakedType: autoScaleNakedType,
+		Fields: []*dsl.FieldDesc{
+			// common fields
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.IconID(),
+
+			// settings
+			fields.AutoScaleZones(),
+			fields.AutoScaleConfig(),
+			fields.AutoScaleServerPrefix(),
+			fields.AutoScaleCPUThresholdUp(),
+			fields.AutoScaleCPUThresholdDown(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	autoScaleUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(autoScaleAPIName),
+		NakedType: autoScaleNakedType,
+		Fields: []*dsl.FieldDesc{
+			// settings
+			fields.AutoScaleZones(),
+			fields.AutoScaleConfig(),
+			fields.AutoScaleServerPrefix(),
+			fields.AutoScaleCPUThresholdUp(),
+			fields.AutoScaleCPUThresholdDown(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	autoScaleStatusView = &dsl.Model{
+		Name:      "AutoScaleStatus",
+		NakedType: meta.Static(naked.AutoScaleRunningStatus{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "LatestLogs",
+				Type: meta.TypeStringSlice,
+			},
+			{
+				Name: "ResourcesText",
+				Type: meta.TypeString,
+			},
+		},
+	}
+)

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -2826,3 +2826,63 @@ func (f *fieldsDef) MonitorLocalRouterSendBytesPerSec() *dsl.FieldDesc {
 		},
 	}
 }
+
+func (f *fieldsDef) AutoScaleAPIKeyID() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "APIKeyID",
+		Type: meta.TypeString,
+		Tags: &dsl.FieldTags{
+			MapConv: "Status.APIKey.ID",
+		},
+	}
+}
+
+func (f *fieldsDef) AutoScaleZones() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Zones",
+		Type: meta.TypeStringSlice,
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.Zones",
+		},
+	}
+}
+
+func (f *fieldsDef) AutoScaleConfig() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Config",
+		Type: meta.TypeString,
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.Config",
+		},
+	}
+}
+
+func (f *fieldsDef) AutoScaleServerPrefix() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "ServerPrefix",
+		Type: meta.TypeString,
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.CPUThresholdScaling.ServerPrefix",
+		},
+	}
+}
+
+func (f *fieldsDef) AutoScaleCPUThresholdUp() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Up",
+		Type: meta.TypeInt,
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.CPUThresholdScaling.Up",
+		},
+	}
+}
+
+func (f *fieldsDef) AutoScaleCPUThresholdDown() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Down",
+		Type: meta.TypeInt,
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.CPUThresholdScaling.Down",
+		},
+	}
+}

--- a/internal/define/names/resource_name.go
+++ b/internal/define/names/resource_name.go
@@ -29,6 +29,7 @@ func ResourceFieldName(resourceName string, form dsl.PayloadForm) string {
 	case form.IsPlural():
 		switch {
 		case
+			resourceName == "AutoScale",
 			resourceName == "ESME",
 			resourceName == "NFS",
 			resourceName == "DNS",

--- a/naked/auto_scale.go
+++ b/naked/auto_scale.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package naked
+
+import (
+	"time"
+
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// AutoScale オートスケール
+type AutoScale struct {
+	ID           types.ID            `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+	Name         string              `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Description  string              `yaml:"description"`
+	Tags         types.Tags          `yaml:"tags"`
+	Icon         *Icon               `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
+	CreatedAt    *time.Time          `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
+	ModifiedAt   *time.Time          `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
+	Availability types.EAvailability `json:",omitempty" yaml:"availability,omitempty" structs:",omitempty"`
+	Provider     *Provider           `json:",omitempty" yaml:"provider,omitempty" structs:",omitempty"`
+	Settings     *AutoScaleSettings  `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string              `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+	Status       *AutoScaleStatus    `json:",omitempty" yaml:"status" structs:",omitempty"`
+	ServiceClass string              `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
+}
+
+// AutoScaleSettingsUpdate オートスケール更新パラメータ
+type AutoScaleSettingsUpdate struct {
+	Settings     *AutoScaleSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string             `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
+// AutoScaleSettings セッティング
+type AutoScaleSettings struct {
+	CPUThresholdScaling *AutoScaleCPUThresholdScaling `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Zones               []string                      `json:"SakuraCloudZones"`
+	Config              string                        `json:",omitempty" yaml:",omitempty"`
+}
+
+type AutoScaleCPUThresholdScaling struct {
+	ServerPrefix string `json:",omitempty" yaml:",omitempty"`
+	Up           int    `json:",omitempty" yaml:",omitempty"`
+	Down         int    `json:",omitempty" yaml:",omitempty"`
+}
+
+// AutoScaleStatus ステータス
+type AutoScaleStatus struct {
+	RegisteredBy string           `json:",omitempty" yaml:",omitempty"`
+	APIKey       *AutoScaleAPIKey `json:",omitempty" yaml:",omitempty"`
+}
+
+type AutoScaleAPIKey struct {
+	ID string `json:",omitempty" yaml:",omitempty"`
+}
+
+// AutoScaleRunningStatus /statusの戻り値
+type AutoScaleRunningStatus struct {
+	LatestLogs    []string
+	ResourcesText string
+}

--- a/stub/zz_api_stubs.go
+++ b/stub/zz_api_stubs.go
@@ -332,6 +332,123 @@ func (s *AutoBackupStub) Delete(ctx context.Context, zone string, id types.ID) e
 }
 
 /*************************************************
+* AutoScaleStub
+*************************************************/
+
+// AutoScaleFindStubResult is expected values of the Find operation
+type AutoScaleFindStubResult struct {
+	Values *iaas.AutoScaleFindResult
+	Err    error
+}
+
+// AutoScaleCreateStubResult is expected values of the Create operation
+type AutoScaleCreateStubResult struct {
+	AutoScale *iaas.AutoScale
+	Err       error
+}
+
+// AutoScaleReadStubResult is expected values of the Read operation
+type AutoScaleReadStubResult struct {
+	AutoScale *iaas.AutoScale
+	Err       error
+}
+
+// AutoScaleUpdateStubResult is expected values of the Update operation
+type AutoScaleUpdateStubResult struct {
+	AutoScale *iaas.AutoScale
+	Err       error
+}
+
+// AutoScaleUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type AutoScaleUpdateSettingsStubResult struct {
+	AutoScale *iaas.AutoScale
+	Err       error
+}
+
+// AutoScaleDeleteStubResult is expected values of the Delete operation
+type AutoScaleDeleteStubResult struct {
+	Err error
+}
+
+// AutoScaleStatusStubResult is expected values of the Status operation
+type AutoScaleStatusStubResult struct {
+	AutoScaleStatus *iaas.AutoScaleStatus
+	Err             error
+}
+
+// AutoScaleStub is for trace AutoScaleOp operations
+type AutoScaleStub struct {
+	FindStubResult           *AutoScaleFindStubResult
+	CreateStubResult         *AutoScaleCreateStubResult
+	ReadStubResult           *AutoScaleReadStubResult
+	UpdateStubResult         *AutoScaleUpdateStubResult
+	UpdateSettingsStubResult *AutoScaleUpdateSettingsStubResult
+	DeleteStubResult         *AutoScaleDeleteStubResult
+	StatusStubResult         *AutoScaleStatusStubResult
+}
+
+// NewAutoScaleStub creates new AutoScaleStub instance
+func NewAutoScaleStub(caller iaas.APICaller) iaas.AutoScaleAPI {
+	return &AutoScaleStub{}
+}
+
+// Find is API call with trace log
+func (s *AutoScaleStub) Find(ctx context.Context, conditions *iaas.FindCondition) (*iaas.AutoScaleFindResult, error) {
+	if s.FindStubResult == nil {
+		log.Fatal("AutoScaleStub.FindStubResult is not set")
+	}
+	return s.FindStubResult.Values, s.FindStubResult.Err
+}
+
+// Create is API call with trace log
+func (s *AutoScaleStub) Create(ctx context.Context, param *iaas.AutoScaleCreateRequest) (*iaas.AutoScale, error) {
+	if s.CreateStubResult == nil {
+		log.Fatal("AutoScaleStub.CreateStubResult is not set")
+	}
+	return s.CreateStubResult.AutoScale, s.CreateStubResult.Err
+}
+
+// Read is API call with trace log
+func (s *AutoScaleStub) Read(ctx context.Context, id types.ID) (*iaas.AutoScale, error) {
+	if s.ReadStubResult == nil {
+		log.Fatal("AutoScaleStub.ReadStubResult is not set")
+	}
+	return s.ReadStubResult.AutoScale, s.ReadStubResult.Err
+}
+
+// Update is API call with trace log
+func (s *AutoScaleStub) Update(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateRequest) (*iaas.AutoScale, error) {
+	if s.UpdateStubResult == nil {
+		log.Fatal("AutoScaleStub.UpdateStubResult is not set")
+	}
+	return s.UpdateStubResult.AutoScale, s.UpdateStubResult.Err
+}
+
+// UpdateSettings is API call with trace log
+func (s *AutoScaleStub) UpdateSettings(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateSettingsRequest) (*iaas.AutoScale, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("AutoScaleStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.AutoScale, s.UpdateSettingsStubResult.Err
+}
+
+// Delete is API call with trace log
+func (s *AutoScaleStub) Delete(ctx context.Context, id types.ID) error {
+	if s.DeleteStubResult == nil {
+		log.Fatal("AutoScaleStub.DeleteStubResult is not set")
+	}
+	return s.DeleteStubResult.Err
+}
+
+// Status is API call with trace log
+func (s *AutoScaleStub) Status(ctx context.Context, id types.ID) (*iaas.AutoScaleStatus, error) {
+	if s.StatusStubResult == nil {
+		log.Fatal("AutoScaleStub.StatusStubResult is not set")
+	}
+	return s.StatusStubResult.AutoScaleStatus, s.StatusStubResult.Err
+}
+
+/*************************************************
 * BillStub
 *************************************************/
 

--- a/test/auto_scale_op_test.go
+++ b/test/auto_scale_op_test.go
@@ -1,0 +1,181 @@
+// Copyright 2022 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/testutil"
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/packages-go/size"
+)
+
+var autoScaleTestServerName = testutil.ResourceName("auto-scale")
+
+func TestAutoScaleOp_CRUD(t *testing.T) {
+	if testutil.IsAccTest() && os.Getenv("SAKURACLOUD_API_KEY_ID") == "" {
+		t.Skip("SAKURACLOUD_API_KEY_ID is required when running the acceptance test")
+	}
+
+	testutil.RunCRUD(t, &testutil.CRUDTestCase{
+		Parallel:           true,
+		SetupAPICallerFunc: singletonAPICaller,
+		Setup: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+			serverOp := iaas.NewServerOp(caller)
+			// ディスクレスサーバを作成
+			_, err := serverOp.Create(ctx, testutil.TestZone(), &iaas.ServerCreateRequest{
+				CPU:      1,
+				MemoryMB: 2 * size.GiB,
+				Name:     autoScaleTestServerName,
+			})
+			return err
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: testAutoScaleCreate,
+			CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+				ExpectValue:  createAutoScaleExpected,
+				IgnoreFields: ignoreAutoScaleFields,
+			}),
+		},
+
+		Read: &testutil.CRUDTestFunc{
+			Func: testAutoScaleRead,
+			CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+				ExpectValue:  createAutoScaleExpected,
+				IgnoreFields: ignoreAutoScaleFields,
+			}),
+		},
+
+		Updates: []*testutil.CRUDTestFunc{
+			{
+				Func: testAutoScaleUpdate,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateAutoScaleExpected,
+					IgnoreFields: ignoreAutoScaleFields,
+				}),
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: testAutoScaleDelete,
+		},
+	})
+}
+
+var (
+	ignoreAutoScaleFields = []string{
+		"ID",
+		"Class",
+		"SettingsHash",
+		"CreatedAt",
+		"ModifiedAt",
+	}
+	createAutoScaleParam = &iaas.AutoScaleCreateRequest{
+		Name:        testutil.ResourceName("container-registry"),
+		Description: "desc",
+		Tags:        []string{"tag1", "tag2"},
+
+		Config:       fmt.Sprintf(autoScaleConfigTemplate, autoScaleTestServerName, testutil.TestZone()),
+		Zones:        []string{testutil.TestZone()},
+		ServerPrefix: autoScaleTestServerName,
+		Up:           80,
+		Down:         50,
+		APIKeyID:     os.Getenv("SAKURACLOUD_API_KEY_ID"),
+	}
+	createAutoScaleExpected = &iaas.AutoScale{
+		Name:         createAutoScaleParam.Name,
+		Description:  createAutoScaleParam.Description,
+		Tags:         createAutoScaleParam.Tags,
+		Availability: types.Availabilities.Available,
+
+		Config:       fmt.Sprintf(autoScaleConfigTemplate, autoScaleTestServerName, testutil.TestZone()),
+		Zones:        []string{testutil.TestZone()},
+		ServerPrefix: autoScaleTestServerName,
+		Up:           80,
+		Down:         50,
+		APIKeyID:     os.Getenv("SAKURACLOUD_API_KEY_ID"),
+	}
+	updateAutoScaleParam = &iaas.AutoScaleUpdateRequest{
+		Name:        testutil.ResourceName("container-registry-upd"),
+		Description: "desc-upd",
+		Tags:        []string{"tag1-upd", "tag2-upd"},
+		IconID:      testIconID,
+
+		Config:       fmt.Sprintf(autoScaleConfigTemplateUpd, autoScaleTestServerName, testutil.TestZone()),
+		Zones:        []string{testutil.TestZone()},
+		ServerPrefix: autoScaleTestServerName,
+		Up:           81,
+		Down:         51,
+	}
+	updateAutoScaleExpected = &iaas.AutoScale{
+		Name:         updateAutoScaleParam.Name,
+		Description:  updateAutoScaleParam.Description,
+		Tags:         updateAutoScaleParam.Tags,
+		Availability: types.Availabilities.Available,
+		IconID:       testIconID,
+
+		Config:       fmt.Sprintf(autoScaleConfigTemplateUpd, autoScaleTestServerName, testutil.TestZone()),
+		Zones:        []string{testutil.TestZone()},
+		ServerPrefix: autoScaleTestServerName,
+		Up:           81,
+		Down:         51,
+		APIKeyID:     os.Getenv("SAKURACLOUD_API_KEY_ID"),
+	}
+)
+
+func testAutoScaleCreate(ctx *testutil.CRUDTestContext, caller iaas.APICaller) (interface{}, error) {
+	client := iaas.NewAutoScaleOp(caller)
+	return client.Create(ctx, createAutoScaleParam)
+}
+
+func testAutoScaleRead(ctx *testutil.CRUDTestContext, caller iaas.APICaller) (interface{}, error) {
+	client := iaas.NewAutoScaleOp(caller)
+	return client.Read(ctx, ctx.ID)
+}
+
+func testAutoScaleUpdate(ctx *testutil.CRUDTestContext, caller iaas.APICaller) (interface{}, error) {
+	client := iaas.NewAutoScaleOp(caller)
+	return client.Update(ctx, ctx.ID, updateAutoScaleParam)
+}
+
+func testAutoScaleDelete(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+	client := iaas.NewAutoScaleOp(caller)
+	return client.Delete(ctx, ctx.ID)
+}
+
+var autoScaleConfigTemplate = `
+resources:
+  - type: Server
+    selector:
+      names: ["%s"]
+      zones: ["%s"]
+
+    shutdown_force: true
+`
+
+var autoScaleConfigTemplateUpd = `
+resources:
+  - type: Server
+    selector:
+      names: ["%s"]
+      zones: ["%s"]
+
+    shutdown_force: true
+
+autoscaler:
+  cooldown: 300
+`

--- a/trace/otel/zz_api_tracer.go
+++ b/trace/otel/zz_api_tracer.go
@@ -38,6 +38,9 @@ func addClientFactoryHooks(cnf *config) {
 	iaas.AddClientFacotyHookFunc("AutoBackup", func(in interface{}) interface{} {
 		return newAutoBackupTracer(in.(iaas.AutoBackupAPI), cnf)
 	})
+	iaas.AddClientFacotyHookFunc("AutoScale", func(in interface{}) interface{} {
+		return newAutoScaleTracer(in.(iaas.AutoScaleAPI), cnf)
+	})
 	iaas.AddClientFacotyHookFunc("Bill", func(in interface{}) interface{} {
 		return newBillTracer(in.(iaas.BillAPI), cnf)
 	})
@@ -689,6 +692,200 @@ func (t *AutoBackupTracer) Delete(ctx context.Context, zone string, id types.ID)
 
 	}
 	return err
+}
+
+/*************************************************
+* AutoScaleTracer
+*************************************************/
+
+// AutoScaleTracer is for trace AutoScaleOp operations
+type AutoScaleTracer struct {
+	Internal iaas.AutoScaleAPI
+	config   *config
+}
+
+// NewAutoScaleTracer creates new AutoScaleTracer instance
+func newAutoScaleTracer(in iaas.AutoScaleAPI, cnf *config) iaas.AutoScaleAPI {
+	return &AutoScaleTracer{
+		Internal: in,
+		config:   cnf,
+	}
+}
+
+// Find is API call with trace log
+func (t *AutoScaleTracer) Find(ctx context.Context, conditions *iaas.FindCondition) (*iaas.AutoScaleFindResult, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libiaas.api.arguments.conditions", forceString(conditions)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "AutoScaleAPI.Find", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	result, err := t.Internal.Find(ctx, conditions)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libiaas.api.results.result", forceString(result)))
+
+	}
+	return result, err
+}
+
+// Create is API call with trace log
+func (t *AutoScaleTracer) Create(ctx context.Context, param *iaas.AutoScaleCreateRequest) (*iaas.AutoScale, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libiaas.api.arguments.param", forceString(param)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "AutoScaleAPI.Create", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultAutoScale, err := t.Internal.Create(ctx, param)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libiaas.api.results.resultAutoScale", forceString(resultAutoScale)))
+
+	}
+	return resultAutoScale, err
+}
+
+// Read is API call with trace log
+func (t *AutoScaleTracer) Read(ctx context.Context, id types.ID) (*iaas.AutoScale, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libiaas.api.arguments.id", forceString(id)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "AutoScaleAPI.Read", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultAutoScale, err := t.Internal.Read(ctx, id)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libiaas.api.results.resultAutoScale", forceString(resultAutoScale)))
+
+	}
+	return resultAutoScale, err
+}
+
+// Update is API call with trace log
+func (t *AutoScaleTracer) Update(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateRequest) (*iaas.AutoScale, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libiaas.api.arguments.id", forceString(id)),
+		attribute.String("libiaas.api.arguments.param", forceString(param)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "AutoScaleAPI.Update", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultAutoScale, err := t.Internal.Update(ctx, id, param)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libiaas.api.results.resultAutoScale", forceString(resultAutoScale)))
+
+	}
+	return resultAutoScale, err
+}
+
+// UpdateSettings is API call with trace log
+func (t *AutoScaleTracer) UpdateSettings(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateSettingsRequest) (*iaas.AutoScale, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libiaas.api.arguments.id", forceString(id)),
+		attribute.String("libiaas.api.arguments.param", forceString(param)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "AutoScaleAPI.UpdateSettings", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultAutoScale, err := t.Internal.UpdateSettings(ctx, id, param)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libiaas.api.results.resultAutoScale", forceString(resultAutoScale)))
+
+	}
+	return resultAutoScale, err
+}
+
+// Delete is API call with trace log
+func (t *AutoScaleTracer) Delete(ctx context.Context, id types.ID) error {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libiaas.api.arguments.id", forceString(id)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "AutoScaleAPI.Delete", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	err := t.Internal.Delete(ctx, id)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+
+	}
+	return err
+}
+
+// Status is API call with trace log
+func (t *AutoScaleTracer) Status(ctx context.Context, id types.ID) (*iaas.AutoScaleStatus, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libiaas.api.arguments.id", forceString(id)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "AutoScaleAPI.Status", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultAutoScaleStatus, err := t.Internal.Status(ctx, id)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libiaas.api.results.resultAutoScaleStatus", forceString(resultAutoScaleStatus)))
+
+	}
+	return resultAutoScaleStatus, err
 }
 
 /*************************************************

--- a/trace/zz_api_tracer.go
+++ b/trace/zz_api_tracer.go
@@ -45,6 +45,9 @@ func addClientFactoryHooks() {
 	iaas.AddClientFacotyHookFunc("AutoBackup", func(in interface{}) interface{} {
 		return NewAutoBackupTracer(in.(iaas.AutoBackupAPI))
 	})
+	iaas.AddClientFacotyHookFunc("AutoScale", func(in interface{}) interface{} {
+		return NewAutoScaleTracer(in.(iaas.AutoScaleAPI))
+	})
 	iaas.AddClientFacotyHookFunc("Bill", func(in interface{}) interface{} {
 		return NewBillTracer(in.(iaas.BillAPI))
 	})
@@ -820,6 +823,241 @@ func (t *AutoBackupTracer) Delete(ctx context.Context, zone string, id types.ID)
 	}
 
 	return err
+}
+
+/*************************************************
+* AutoScaleTracer
+*************************************************/
+
+// AutoScaleTracer is for trace AutoScaleOp operations
+type AutoScaleTracer struct {
+	Internal iaas.AutoScaleAPI
+}
+
+// NewAutoScaleTracer creates new AutoScaleTracer instance
+func NewAutoScaleTracer(in iaas.AutoScaleAPI) iaas.AutoScaleAPI {
+	return &AutoScaleTracer{
+		Internal: in,
+	}
+}
+
+// Find is API call with trace log
+func (t *AutoScaleTracer) Find(ctx context.Context, conditions *iaas.FindCondition) (*iaas.AutoScaleFindResult, error) {
+	log.Println("[TRACE] AutoScaleAPI.Find start")
+	targetArguments := struct {
+		Argconditions *iaas.FindCondition `json:"conditions"`
+	}{
+		Argconditions: conditions,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoScaleAPI.Find end")
+	}()
+
+	result, err := t.Internal.Find(ctx, conditions)
+	targetResults := struct {
+		Result *iaas.AutoScaleFindResult
+		Error  error
+	}{
+		Result: result,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return result, err
+}
+
+// Create is API call with trace log
+func (t *AutoScaleTracer) Create(ctx context.Context, param *iaas.AutoScaleCreateRequest) (*iaas.AutoScale, error) {
+	log.Println("[TRACE] AutoScaleAPI.Create start")
+	targetArguments := struct {
+		Argparam *iaas.AutoScaleCreateRequest `json:"param"`
+	}{
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoScaleAPI.Create end")
+	}()
+
+	resultAutoScale, err := t.Internal.Create(ctx, param)
+	targetResults := struct {
+		AutoScale *iaas.AutoScale
+		Error     error
+	}{
+		AutoScale: resultAutoScale,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoScale, err
+}
+
+// Read is API call with trace log
+func (t *AutoScaleTracer) Read(ctx context.Context, id types.ID) (*iaas.AutoScale, error) {
+	log.Println("[TRACE] AutoScaleAPI.Read start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoScaleAPI.Read end")
+	}()
+
+	resultAutoScale, err := t.Internal.Read(ctx, id)
+	targetResults := struct {
+		AutoScale *iaas.AutoScale
+		Error     error
+	}{
+		AutoScale: resultAutoScale,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoScale, err
+}
+
+// Update is API call with trace log
+func (t *AutoScaleTracer) Update(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateRequest) (*iaas.AutoScale, error) {
+	log.Println("[TRACE] AutoScaleAPI.Update start")
+	targetArguments := struct {
+		Argid    types.ID                     `json:"id"`
+		Argparam *iaas.AutoScaleUpdateRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoScaleAPI.Update end")
+	}()
+
+	resultAutoScale, err := t.Internal.Update(ctx, id, param)
+	targetResults := struct {
+		AutoScale *iaas.AutoScale
+		Error     error
+	}{
+		AutoScale: resultAutoScale,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoScale, err
+}
+
+// UpdateSettings is API call with trace log
+func (t *AutoScaleTracer) UpdateSettings(ctx context.Context, id types.ID, param *iaas.AutoScaleUpdateSettingsRequest) (*iaas.AutoScale, error) {
+	log.Println("[TRACE] AutoScaleAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argid    types.ID                             `json:"id"`
+		Argparam *iaas.AutoScaleUpdateSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoScaleAPI.UpdateSettings end")
+	}()
+
+	resultAutoScale, err := t.Internal.UpdateSettings(ctx, id, param)
+	targetResults := struct {
+		AutoScale *iaas.AutoScale
+		Error     error
+	}{
+		AutoScale: resultAutoScale,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoScale, err
+}
+
+// Delete is API call with trace log
+func (t *AutoScaleTracer) Delete(ctx context.Context, id types.ID) error {
+	log.Println("[TRACE] AutoScaleAPI.Delete start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoScaleAPI.Delete end")
+	}()
+
+	err := t.Internal.Delete(ctx, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// Status is API call with trace log
+func (t *AutoScaleTracer) Status(ctx context.Context, id types.ID) (*iaas.AutoScaleStatus, error) {
+	log.Println("[TRACE] AutoScaleAPI.Status start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoScaleAPI.Status end")
+	}()
+
+	resultAutoScaleStatus, err := t.Internal.Status(ctx, id)
+	targetResults := struct {
+		AutoScaleStatus *iaas.AutoScaleStatus
+		Error           error
+	}{
+		AutoScaleStatus: resultAutoScaleStatus,
+		Error:           err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoScaleStatus, err
 }
 
 /*************************************************

--- a/zz_api_ops.go
+++ b/zz_api_ops.go
@@ -51,6 +51,14 @@ func init() {
 		}
 	})
 
+	SetClientFactoryFunc("AutoScale", func(caller APICaller) interface{} {
+		return &AutoScaleOp{
+			Client:     caller,
+			PathSuffix: "api/cloud/1.1",
+			PathName:   "commonserviceitem",
+		}
+	})
+
 	SetClientFactoryFunc("Bill", func(caller APICaller) interface{} {
 		return &BillOp{
 			Client:     caller,
@@ -1077,6 +1085,268 @@ func (o *AutoBackupOp) Delete(ctx context.Context, zone string, id types.ID) err
 	// build results
 
 	return nil
+}
+
+/*************************************************
+* AutoScaleOp
+*************************************************/
+
+// AutoScaleOp implements AutoScaleAPI interface
+type AutoScaleOp struct {
+	// Client APICaller
+	Client APICaller
+	// PathSuffix is used when building URL
+	PathSuffix string
+	// PathName is used when building URL
+	PathName string
+}
+
+// NewAutoScaleOp creates new AutoScaleOp instance
+func NewAutoScaleOp(caller APICaller) AutoScaleAPI {
+	return GetClientFactoryFunc("AutoScale")(caller).(AutoScaleAPI)
+}
+
+// Find is API call
+func (o *AutoScaleOp) Find(ctx context.Context, conditions *FindCondition) (*AutoScaleFindResult, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"conditions": conditions,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformFindArgs(conditions)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformFindResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results, err
+}
+
+// Create is API call
+func (o *AutoScaleOp) Create(ctx context.Context, param *AutoScaleCreateRequest) (*AutoScale, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformCreateArgs(param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformCreateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoScale, nil
+}
+
+// Read is API call
+func (o *AutoScaleOp) Read(ctx context.Context, id types.ID) (*AutoScale, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformReadResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoScale, nil
+}
+
+// Update is API call
+func (o *AutoScaleOp) Update(ctx context.Context, id types.ID, param *AutoScaleUpdateRequest) (*AutoScale, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoScale, nil
+}
+
+// UpdateSettings is API call
+func (o *AutoScaleOp) UpdateSettings(ctx context.Context, id types.ID, param *AutoScaleUpdateSettingsRequest) (*AutoScale, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoScale, nil
+}
+
+// Delete is API call
+func (o *AutoScaleOp) Delete(ctx context.Context, id types.ID) error {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	// build results
+
+	return nil
+}
+
+// Status is API call
+func (o *AutoScaleOp) Status(ctx context.Context, id types.ID) (*AutoScaleStatus, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/autoscale/status", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformStatusResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoScaleStatus, nil
 }
 
 /*************************************************

--- a/zz_api_transformers.go
+++ b/zz_api_transformers.go
@@ -542,6 +542,186 @@ func (o *AutoBackupOp) transformUpdateSettingsResults(data []byte) (*autoBackupU
 	return results, nil
 }
 
+func (o *AutoScaleOp) transformFindArgs(conditions *FindCondition) (*autoScaleFindRequestEnvelope, error) {
+	if conditions == nil {
+		conditions = &FindCondition{}
+	}
+	var arg0 interface{} = conditions
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+	}
+
+	v := &autoScaleFindRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *AutoScaleOp) transformFindResults(data []byte) (*AutoScaleFindResult, error) {
+	nakedResponse := &autoScaleFindResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &AutoScaleFindResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *AutoScaleOp) transformCreateArgs(param *AutoScaleCreateRequest) (*autoScaleCreateRequestEnvelope, error) {
+	if param == nil {
+		param = &AutoScaleCreateRequest{}
+	}
+	var arg0 interface{} = param
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+	}
+
+	v := &autoScaleCreateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *AutoScaleOp) transformCreateResults(data []byte) (*autoScaleCreateResult, error) {
+	nakedResponse := &autoScaleCreateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoScaleCreateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *AutoScaleOp) transformReadResults(data []byte) (*autoScaleReadResult, error) {
+	nakedResponse := &autoScaleReadResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoScaleReadResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *AutoScaleOp) transformUpdateArgs(id types.ID, param *AutoScaleUpdateRequest) (*autoScaleUpdateRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &AutoScaleUpdateRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &autoScaleUpdateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *AutoScaleOp) transformUpdateResults(data []byte) (*autoScaleUpdateResult, error) {
+	nakedResponse := &autoScaleUpdateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoScaleUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *AutoScaleOp) transformUpdateSettingsArgs(id types.ID, param *AutoScaleUpdateSettingsRequest) (*autoScaleUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &AutoScaleUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &autoScaleUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *AutoScaleOp) transformUpdateSettingsResults(data []byte) (*autoScaleUpdateSettingsResult, error) {
+	nakedResponse := &autoScaleUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoScaleUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *AutoScaleOp) transformStatusResults(data []byte) (*autoScaleStatusResult, error) {
+	nakedResponse := &autoScaleStatusResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoScaleStatusResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *BillOp) transformByContractResults(data []byte) (*BillByContractResult, error) {
 	nakedResponse := &billByContractResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {

--- a/zz_apis.go
+++ b/zz_apis.go
@@ -65,6 +65,21 @@ type AutoBackupAPI interface {
 }
 
 /*************************************************
+* AutoScaleAPI
+*************************************************/
+
+// AutoScaleAPI is interface for operate AutoScale resource
+type AutoScaleAPI interface {
+	Find(ctx context.Context, conditions *FindCondition) (*AutoScaleFindResult, error)
+	Create(ctx context.Context, param *AutoScaleCreateRequest) (*AutoScale, error)
+	Read(ctx context.Context, id types.ID) (*AutoScale, error)
+	Update(ctx context.Context, id types.ID, param *AutoScaleUpdateRequest) (*AutoScale, error)
+	UpdateSettings(ctx context.Context, id types.ID, param *AutoScaleUpdateSettingsRequest) (*AutoScale, error)
+	Delete(ctx context.Context, id types.ID) error
+	Status(ctx context.Context, id types.ID) (*AutoScaleStatus, error)
+}
+
+/*************************************************
 * BillAPI
 *************************************************/
 

--- a/zz_envelopes.go
+++ b/zz_envelopes.go
@@ -217,6 +217,80 @@ type autoBackupUpdateSettingsResponseEnvelope struct {
 	CommonServiceItem *naked.AutoBackup `json:",omitempty"`
 }
 
+// autoScaleFindRequestEnvelope is envelop of API request
+type autoScaleFindRequestEnvelope struct {
+	Count   int             `mapconv:",omitempty"`
+	From    int             `mapconv:",omitempty"`
+	Sort    search.SortKeys `json:",omitempty" mapconv:",omitempty"`
+	Filter  search.Filter   `json:",omitempty" mapconv:",omitempty"`
+	Include []string        `json:",omitempty" mapconv:",omitempty"`
+	Exclude []string        `json:",omitempty" mapconv:",omitempty"`
+}
+
+// autoScaleFindResponseEnvelope is envelop of API response
+type autoScaleFindResponseEnvelope struct {
+	Total int `json:",omitempty"` // トータル件数
+	From  int `json:",omitempty"` // ページング開始ページ
+	Count int `json:",omitempty"` // 件数
+
+	CommonServiceItems []*naked.AutoScale `json:",omitempty"`
+}
+
+// autoScaleCreateRequestEnvelope is envelop of API request
+type autoScaleCreateRequestEnvelope struct {
+	CommonServiceItem *naked.AutoScale `json:",omitempty"`
+}
+
+// autoScaleCreateResponseEnvelope is envelop of API response
+type autoScaleCreateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.AutoScale `json:",omitempty"`
+}
+
+// autoScaleReadResponseEnvelope is envelop of API response
+type autoScaleReadResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.AutoScale `json:",omitempty"`
+}
+
+// autoScaleUpdateRequestEnvelope is envelop of API request
+type autoScaleUpdateRequestEnvelope struct {
+	CommonServiceItem *naked.AutoScale `json:",omitempty"`
+}
+
+// autoScaleUpdateResponseEnvelope is envelop of API response
+type autoScaleUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.AutoScale `json:",omitempty"`
+}
+
+// autoScaleUpdateSettingsRequestEnvelope is envelop of API request
+type autoScaleUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.AutoScaleSettingsUpdate `json:",omitempty"`
+}
+
+// autoScaleUpdateSettingsResponseEnvelope is envelop of API response
+type autoScaleUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.AutoScale `json:",omitempty"`
+}
+
+// autoScaleStatusResponseEnvelope is envelop of API response
+type autoScaleStatusResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	AutoScale *naked.AutoScaleRunningStatus `json:",omitempty"`
+}
+
 // billByContractResponseEnvelope is envelop of API response
 type billByContractResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数

--- a/zz_models.go
+++ b/zz_models.go
@@ -2098,6 +2098,724 @@ func (o *AutoBackupUpdateSettingsRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* AutoScale
+*************************************************/
+
+// AutoScale represents API parameter/response structure
+type AutoScale struct {
+	ID           types.ID
+	Name         string
+	Description  string
+	Tags         types.Tags
+	Availability types.EAvailability
+	IconID       types.ID `mapconv:"Icon.ID"`
+	CreatedAt    time.Time
+	ModifiedAt   time.Time
+	Zones        []string `mapconv:"Settings.Zones"`
+	Config       string   `mapconv:"Settings.Config"`
+	ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+	Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+	Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+	SettingsHash string   `json:",omitempty" mapconv:",omitempty"`
+	APIKeyID     string   `mapconv:"Status.APIKey.ID"`
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *AutoScale) setDefaults() interface{} {
+	return &struct {
+		ID           types.ID
+		Name         string
+		Description  string
+		Tags         types.Tags
+		Availability types.EAvailability
+		IconID       types.ID `mapconv:"Icon.ID"`
+		CreatedAt    time.Time
+		ModifiedAt   time.Time
+		Zones        []string `mapconv:"Settings.Zones"`
+		Config       string   `mapconv:"Settings.Config"`
+		ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+		Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+		Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+		SettingsHash string   `json:",omitempty" mapconv:",omitempty"`
+		APIKeyID     string   `mapconv:"Status.APIKey.ID"`
+	}{
+		ID:           o.GetID(),
+		Name:         o.GetName(),
+		Description:  o.GetDescription(),
+		Tags:         o.GetTags(),
+		Availability: o.GetAvailability(),
+		IconID:       o.GetIconID(),
+		CreatedAt:    o.GetCreatedAt(),
+		ModifiedAt:   o.GetModifiedAt(),
+		Zones:        o.GetZones(),
+		Config:       o.GetConfig(),
+		ServerPrefix: o.GetServerPrefix(),
+		Up:           o.GetUp(),
+		Down:         o.GetDown(),
+		SettingsHash: o.GetSettingsHash(),
+		APIKeyID:     o.GetAPIKeyID(),
+	}
+}
+
+// GetID returns value of ID
+func (o *AutoScale) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *AutoScale) SetID(v types.ID) {
+	o.ID = v
+}
+
+// SetStringID .
+func (o *AutoScale) SetStringID(id string) {
+	accessor.SetStringID(o, id)
+}
+
+// GetStringID .
+func (o *AutoScale) GetStringID() string {
+	return accessor.GetStringID(o)
+}
+
+// SetInt64ID .
+func (o *AutoScale) SetInt64ID(id int64) {
+	accessor.SetInt64ID(o, id)
+}
+
+// GetInt64ID .
+func (o *AutoScale) GetInt64ID() int64 {
+	return accessor.GetInt64ID(o)
+}
+
+// GetName returns value of Name
+func (o *AutoScale) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *AutoScale) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *AutoScale) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *AutoScale) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *AutoScale) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *AutoScale) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *AutoScale) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *AutoScale) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *AutoScale) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *AutoScale) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetAvailability returns value of Availability
+func (o *AutoScale) GetAvailability() types.EAvailability {
+	return o.Availability
+}
+
+// SetAvailability sets value to Availability
+func (o *AutoScale) SetAvailability(v types.EAvailability) {
+	o.Availability = v
+}
+
+// GetIconID returns value of IconID
+func (o *AutoScale) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *AutoScale) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetCreatedAt returns value of CreatedAt
+func (o *AutoScale) GetCreatedAt() time.Time {
+	return o.CreatedAt
+}
+
+// SetCreatedAt sets value to CreatedAt
+func (o *AutoScale) SetCreatedAt(v time.Time) {
+	o.CreatedAt = v
+}
+
+// GetModifiedAt returns value of ModifiedAt
+func (o *AutoScale) GetModifiedAt() time.Time {
+	return o.ModifiedAt
+}
+
+// SetModifiedAt sets value to ModifiedAt
+func (o *AutoScale) SetModifiedAt(v time.Time) {
+	o.ModifiedAt = v
+}
+
+// GetZones returns value of Zones
+func (o *AutoScale) GetZones() []string {
+	return o.Zones
+}
+
+// SetZones sets value to Zones
+func (o *AutoScale) SetZones(v []string) {
+	o.Zones = v
+}
+
+// GetConfig returns value of Config
+func (o *AutoScale) GetConfig() string {
+	return o.Config
+}
+
+// SetConfig sets value to Config
+func (o *AutoScale) SetConfig(v string) {
+	o.Config = v
+}
+
+// GetServerPrefix returns value of ServerPrefix
+func (o *AutoScale) GetServerPrefix() string {
+	return o.ServerPrefix
+}
+
+// SetServerPrefix sets value to ServerPrefix
+func (o *AutoScale) SetServerPrefix(v string) {
+	o.ServerPrefix = v
+}
+
+// GetUp returns value of Up
+func (o *AutoScale) GetUp() int {
+	return o.Up
+}
+
+// SetUp sets value to Up
+func (o *AutoScale) SetUp(v int) {
+	o.Up = v
+}
+
+// GetDown returns value of Down
+func (o *AutoScale) GetDown() int {
+	return o.Down
+}
+
+// SetDown sets value to Down
+func (o *AutoScale) SetDown(v int) {
+	o.Down = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *AutoScale) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *AutoScale) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+// GetAPIKeyID returns value of APIKeyID
+func (o *AutoScale) GetAPIKeyID() string {
+	return o.APIKeyID
+}
+
+// SetAPIKeyID sets value to APIKeyID
+func (o *AutoScale) SetAPIKeyID(v string) {
+	o.APIKeyID = v
+}
+
+/*************************************************
+* AutoScaleCreateRequest
+*************************************************/
+
+// AutoScaleCreateRequest represents API parameter/response structure
+type AutoScaleCreateRequest struct {
+	Name         string
+	Description  string
+	Tags         types.Tags
+	IconID       types.ID `mapconv:"Icon.ID"`
+	Zones        []string `mapconv:"Settings.Zones"`
+	Config       string   `mapconv:"Settings.Config"`
+	ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+	Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+	Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+	APIKeyID     string   `mapconv:"Status.APIKey.ID"`
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *AutoScaleCreateRequest) setDefaults() interface{} {
+	return &struct {
+		Name         string
+		Description  string
+		Tags         types.Tags
+		IconID       types.ID `mapconv:"Icon.ID"`
+		Zones        []string `mapconv:"Settings.Zones"`
+		Config       string   `mapconv:"Settings.Config"`
+		ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+		Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+		Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+		APIKeyID     string   `mapconv:"Status.APIKey.ID"`
+		Class        string   `mapconv:"Provider.Class"`
+		ServiceClass string
+	}{
+		Name:         o.GetName(),
+		Description:  o.GetDescription(),
+		Tags:         o.GetTags(),
+		IconID:       o.GetIconID(),
+		Zones:        o.GetZones(),
+		Config:       o.GetConfig(),
+		ServerPrefix: o.GetServerPrefix(),
+		Up:           o.GetUp(),
+		Down:         o.GetDown(),
+		APIKeyID:     o.GetAPIKeyID(),
+		Class:        "autoscale",
+		ServiceClass: "cloud/autoscale/1",
+	}
+}
+
+// GetName returns value of Name
+func (o *AutoScaleCreateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *AutoScaleCreateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *AutoScaleCreateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *AutoScaleCreateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *AutoScaleCreateRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *AutoScaleCreateRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *AutoScaleCreateRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *AutoScaleCreateRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *AutoScaleCreateRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *AutoScaleCreateRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *AutoScaleCreateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *AutoScaleCreateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetZones returns value of Zones
+func (o *AutoScaleCreateRequest) GetZones() []string {
+	return o.Zones
+}
+
+// SetZones sets value to Zones
+func (o *AutoScaleCreateRequest) SetZones(v []string) {
+	o.Zones = v
+}
+
+// GetConfig returns value of Config
+func (o *AutoScaleCreateRequest) GetConfig() string {
+	return o.Config
+}
+
+// SetConfig sets value to Config
+func (o *AutoScaleCreateRequest) SetConfig(v string) {
+	o.Config = v
+}
+
+// GetServerPrefix returns value of ServerPrefix
+func (o *AutoScaleCreateRequest) GetServerPrefix() string {
+	return o.ServerPrefix
+}
+
+// SetServerPrefix sets value to ServerPrefix
+func (o *AutoScaleCreateRequest) SetServerPrefix(v string) {
+	o.ServerPrefix = v
+}
+
+// GetUp returns value of Up
+func (o *AutoScaleCreateRequest) GetUp() int {
+	return o.Up
+}
+
+// SetUp sets value to Up
+func (o *AutoScaleCreateRequest) SetUp(v int) {
+	o.Up = v
+}
+
+// GetDown returns value of Down
+func (o *AutoScaleCreateRequest) GetDown() int {
+	return o.Down
+}
+
+// SetDown sets value to Down
+func (o *AutoScaleCreateRequest) SetDown(v int) {
+	o.Down = v
+}
+
+// GetAPIKeyID returns value of APIKeyID
+func (o *AutoScaleCreateRequest) GetAPIKeyID() string {
+	return o.APIKeyID
+}
+
+// SetAPIKeyID sets value to APIKeyID
+func (o *AutoScaleCreateRequest) SetAPIKeyID(v string) {
+	o.APIKeyID = v
+}
+
+/*************************************************
+* AutoScaleUpdateRequest
+*************************************************/
+
+// AutoScaleUpdateRequest represents API parameter/response structure
+type AutoScaleUpdateRequest struct {
+	Name         string
+	Description  string
+	Tags         types.Tags
+	IconID       types.ID `mapconv:"Icon.ID"`
+	Zones        []string `mapconv:"Settings.Zones"`
+	Config       string   `mapconv:"Settings.Config"`
+	ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+	Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+	Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+	SettingsHash string   `json:",omitempty" mapconv:",omitempty"`
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *AutoScaleUpdateRequest) setDefaults() interface{} {
+	return &struct {
+		Name         string
+		Description  string
+		Tags         types.Tags
+		IconID       types.ID `mapconv:"Icon.ID"`
+		Zones        []string `mapconv:"Settings.Zones"`
+		Config       string   `mapconv:"Settings.Config"`
+		ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+		Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+		Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+		SettingsHash string   `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Name:         o.GetName(),
+		Description:  o.GetDescription(),
+		Tags:         o.GetTags(),
+		IconID:       o.GetIconID(),
+		Zones:        o.GetZones(),
+		Config:       o.GetConfig(),
+		ServerPrefix: o.GetServerPrefix(),
+		Up:           o.GetUp(),
+		Down:         o.GetDown(),
+		SettingsHash: o.GetSettingsHash(),
+	}
+}
+
+// GetName returns value of Name
+func (o *AutoScaleUpdateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *AutoScaleUpdateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *AutoScaleUpdateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *AutoScaleUpdateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *AutoScaleUpdateRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *AutoScaleUpdateRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *AutoScaleUpdateRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *AutoScaleUpdateRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *AutoScaleUpdateRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *AutoScaleUpdateRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *AutoScaleUpdateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *AutoScaleUpdateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetZones returns value of Zones
+func (o *AutoScaleUpdateRequest) GetZones() []string {
+	return o.Zones
+}
+
+// SetZones sets value to Zones
+func (o *AutoScaleUpdateRequest) SetZones(v []string) {
+	o.Zones = v
+}
+
+// GetConfig returns value of Config
+func (o *AutoScaleUpdateRequest) GetConfig() string {
+	return o.Config
+}
+
+// SetConfig sets value to Config
+func (o *AutoScaleUpdateRequest) SetConfig(v string) {
+	o.Config = v
+}
+
+// GetServerPrefix returns value of ServerPrefix
+func (o *AutoScaleUpdateRequest) GetServerPrefix() string {
+	return o.ServerPrefix
+}
+
+// SetServerPrefix sets value to ServerPrefix
+func (o *AutoScaleUpdateRequest) SetServerPrefix(v string) {
+	o.ServerPrefix = v
+}
+
+// GetUp returns value of Up
+func (o *AutoScaleUpdateRequest) GetUp() int {
+	return o.Up
+}
+
+// SetUp sets value to Up
+func (o *AutoScaleUpdateRequest) SetUp(v int) {
+	o.Up = v
+}
+
+// GetDown returns value of Down
+func (o *AutoScaleUpdateRequest) GetDown() int {
+	return o.Down
+}
+
+// SetDown sets value to Down
+func (o *AutoScaleUpdateRequest) SetDown(v int) {
+	o.Down = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *AutoScaleUpdateRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *AutoScaleUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* AutoScaleUpdateSettingsRequest
+*************************************************/
+
+// AutoScaleUpdateSettingsRequest represents API parameter/response structure
+type AutoScaleUpdateSettingsRequest struct {
+	Zones        []string `mapconv:"Settings.Zones"`
+	Config       string   `mapconv:"Settings.Config"`
+	ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+	Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+	Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+	SettingsHash string   `json:",omitempty" mapconv:",omitempty"`
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *AutoScaleUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Zones        []string `mapconv:"Settings.Zones"`
+		Config       string   `mapconv:"Settings.Config"`
+		ServerPrefix string   `mapconv:"Settings.CPUThresholdScaling.ServerPrefix"`
+		Up           int      `mapconv:"Settings.CPUThresholdScaling.Up"`
+		Down         int      `mapconv:"Settings.CPUThresholdScaling.Down"`
+		SettingsHash string   `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Zones:        o.GetZones(),
+		Config:       o.GetConfig(),
+		ServerPrefix: o.GetServerPrefix(),
+		Up:           o.GetUp(),
+		Down:         o.GetDown(),
+		SettingsHash: o.GetSettingsHash(),
+	}
+}
+
+// GetZones returns value of Zones
+func (o *AutoScaleUpdateSettingsRequest) GetZones() []string {
+	return o.Zones
+}
+
+// SetZones sets value to Zones
+func (o *AutoScaleUpdateSettingsRequest) SetZones(v []string) {
+	o.Zones = v
+}
+
+// GetConfig returns value of Config
+func (o *AutoScaleUpdateSettingsRequest) GetConfig() string {
+	return o.Config
+}
+
+// SetConfig sets value to Config
+func (o *AutoScaleUpdateSettingsRequest) SetConfig(v string) {
+	o.Config = v
+}
+
+// GetServerPrefix returns value of ServerPrefix
+func (o *AutoScaleUpdateSettingsRequest) GetServerPrefix() string {
+	return o.ServerPrefix
+}
+
+// SetServerPrefix sets value to ServerPrefix
+func (o *AutoScaleUpdateSettingsRequest) SetServerPrefix(v string) {
+	o.ServerPrefix = v
+}
+
+// GetUp returns value of Up
+func (o *AutoScaleUpdateSettingsRequest) GetUp() int {
+	return o.Up
+}
+
+// SetUp sets value to Up
+func (o *AutoScaleUpdateSettingsRequest) SetUp(v int) {
+	o.Up = v
+}
+
+// GetDown returns value of Down
+func (o *AutoScaleUpdateSettingsRequest) GetDown() int {
+	return o.Down
+}
+
+// SetDown sets value to Down
+func (o *AutoScaleUpdateSettingsRequest) SetDown(v int) {
+	o.Down = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *AutoScaleUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *AutoScaleUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* AutoScaleStatus
+*************************************************/
+
+// AutoScaleStatus represents API parameter/response structure
+type AutoScaleStatus struct {
+	LatestLogs    []string
+	ResourcesText string
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *AutoScaleStatus) setDefaults() interface{} {
+	return &struct {
+		LatestLogs    []string
+		ResourcesText string
+	}{
+		LatestLogs:    o.GetLatestLogs(),
+		ResourcesText: o.GetResourcesText(),
+	}
+}
+
+// GetLatestLogs returns value of LatestLogs
+func (o *AutoScaleStatus) GetLatestLogs() []string {
+	return o.LatestLogs
+}
+
+// SetLatestLogs sets value to LatestLogs
+func (o *AutoScaleStatus) SetLatestLogs(v []string) {
+	o.LatestLogs = v
+}
+
+// GetResourcesText returns value of ResourcesText
+func (o *AutoScaleStatus) GetResourcesText() string {
+	return o.ResourcesText
+}
+
+// SetResourcesText sets value to ResourcesText
+func (o *AutoScaleStatus) SetResourcesText(v string) {
+	o.ResourcesText = v
+}
+
+/*************************************************
 * Bill
 *************************************************/
 

--- a/zz_result.go
+++ b/zz_result.go
@@ -144,6 +144,59 @@ type autoBackupUpdateSettingsResult struct {
 	AutoBackup *AutoBackup `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// AutoScaleFindResult represents the Result of API
+type AutoScaleFindResult struct {
+	Total int `json:",omitempty"` // Total count of target resources
+	From  int `json:",omitempty"` // Current page number
+	Count int `json:",omitempty"` // Count of current page
+
+	AutoScale []*AutoScale `json:",omitempty" mapconv:"[]CommonServiceItems,omitempty,recursive"`
+}
+
+// Values returns find results
+func (r *AutoScaleFindResult) Values() []interface{} {
+	var results []interface{}
+	for _, v := range r.AutoScale {
+		results = append(results, v)
+	}
+	return results
+}
+
+// autoScaleCreateResult represents the Result of API
+type autoScaleCreateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoScale *AutoScale `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// autoScaleReadResult represents the Result of API
+type autoScaleReadResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoScale *AutoScale `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// autoScaleUpdateResult represents the Result of API
+type autoScaleUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoScale *AutoScale `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// autoScaleUpdateSettingsResult represents the Result of API
+type autoScaleUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoScale *AutoScale `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// autoScaleStatusResult represents the Result of API
+type autoScaleStatusResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoScaleStatus *AutoScaleStatus `json:",omitempty" mapconv:"AutoScale,omitempty,recursive"`
+}
+
 // BillByContractResult represents the Result of API
 type BillByContractResult struct {
 	Total int `json:",omitempty"` // Total count of target resources


### PR DESCRIPTION
オートスケールのCRUD+L操作+αを行うためのAPIを追加

```go
type AutoScaleAPI interface {
	Find(ctx context.Context, conditions *FindCondition) (*AutoScaleFindResult, error)
	Create(ctx context.Context, param *AutoScaleCreateRequest) (*AutoScale, error)
	Read(ctx context.Context, id types.ID) (*AutoScale, error)
	Update(ctx context.Context, id types.ID, param *AutoScaleUpdateRequest) (*AutoScale, error)
	UpdateSettings(ctx context.Context, id types.ID, param *AutoScaleUpdateSettingsRequest) (*AutoScale, error)
	Delete(ctx context.Context, id types.ID) error
	Status(ctx context.Context, id types.ID) (*AutoScaleStatus, error)
}
```