### PR TITLE
VPCルータ: サイト間VPN接続パラメータ

### DIFF
--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -907,7 +907,7 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "SiteToSiteIPsecVPN",
 				Type: m.vpcRouterSiteToSiteIPsecVPN(),
 				Tags: &dsl.FieldTags{
-					MapConv: "Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive",
+					MapConv: "Router.SiteToSiteIPsecVPN,omitempty,recursive",
 				},
 			},
 			{
@@ -1251,6 +1251,36 @@ func (m *modelsDef) vpcRouterRemoteAccessUser() *dsl.Model {
 func (m *modelsDef) vpcRouterSiteToSiteIPsecVPN() *dsl.Model {
 	return &dsl.Model{
 		Name:      "VPCRouterSiteToSiteIPsecVPN",
+		NakedType: meta.Static(naked.VPCRouterSiteToSiteIPsecVPN{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "Config",
+				Type: m.vpcRouterSiteToSiteIPsecVPNConfig(),
+				Tags: &dsl.FieldTags{
+					MapConv: "[]Config,omitempty,recursive",
+				},
+			},
+			{
+				Name: "IKE",
+				Type: m.vpcRouterSiteToSiteIPsecVPNIKE(),
+				Tags: &dsl.FieldTags{
+					MapConv: ",omitempty,recursive",
+				},
+			},
+			{
+				Name: "ESP",
+				Type: m.vpcRouterSiteToSiteIPsecVPNESP(),
+				Tags: &dsl.FieldTags{
+					MapConv: ",omitempty,recursive",
+				},
+			},
+		},
+	}
+}
+
+func (m *modelsDef) vpcRouterSiteToSiteIPsecVPNConfig() *dsl.Model {
+	return &dsl.Model{
+		Name:      "VPCRouterSiteToSiteIPsecVPNConfig",
 		NakedType: meta.Static(naked.VPCRouterSiteToSiteIPsecVPNConfig{}),
 		IsArray:   true,
 		Fields: []*dsl.FieldDesc{
@@ -1273,6 +1303,56 @@ func (m *modelsDef) vpcRouterSiteToSiteIPsecVPN() *dsl.Model {
 			{
 				Name: "LocalPrefix",
 				Type: meta.TypeStringSlice,
+			},
+		},
+	}
+}
+
+func (m *modelsDef) vpcRouterSiteToSiteIPsecVPNIKE() *dsl.Model {
+	return &dsl.Model{
+		Name:      "VPCRouterSiteToSiteIPsecVPNIKE",
+		NakedType: meta.Static(naked.VPCRouterSiteToSiteIPsecVPNIKE{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "Lifetime",
+				Type: meta.TypeInt,
+			},
+			{
+				Name: "DPD",
+				Type: m.vpcRouterSiteToSiteIPsecVPNIKEDPD(),
+				Tags: &dsl.FieldTags{
+					MapConv: ",omitempty,recursive",
+				},
+			},
+		},
+	}
+}
+
+func (m *modelsDef) vpcRouterSiteToSiteIPsecVPNIKEDPD() *dsl.Model {
+	return &dsl.Model{
+		Name:      "VPCRouterSiteToSiteIPsecVPNIKEDPD",
+		NakedType: meta.Static(naked.VPCRouterSiteToSiteIPsecVPNIKEDPD{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "Interval",
+				Type: meta.TypeInt,
+			},
+			{
+				Name: "Timeout",
+				Type: meta.TypeInt,
+			},
+		},
+	}
+}
+
+func (m *modelsDef) vpcRouterSiteToSiteIPsecVPNESP() *dsl.Model {
+	return &dsl.Model{
+		Name:      "VPCRouterSiteToSiteIPsecVPNESP",
+		NakedType: meta.Static(naked.VPCRouterSiteToSiteIPsecVPNESP{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "Lifetime",
+				Type: meta.TypeInt,
 			},
 		},
 	}

--- a/naked/vpc_router.go
+++ b/naked/vpc_router.go
@@ -472,6 +472,8 @@ func (f *VPCRouterRemoteAccessUsers) MarshalJSON() ([]byte, error) {
 // VPCRouterSiteToSiteIPsecVPN サイト間VPN
 type VPCRouterSiteToSiteIPsecVPN struct {
 	Config  []*VPCRouterSiteToSiteIPsecVPNConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	IKE     *VPCRouterSiteToSiteIPsecVPNIKE      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	ESP     *VPCRouterSiteToSiteIPsecVPNESP      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	Enabled types.StringFlag                     `yaml:"enabled"`
 }
 
@@ -495,6 +497,23 @@ type VPCRouterSiteToSiteIPsecVPNConfig struct {
 	RemoteID        string   `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	Routes          []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	LocalPrefix     []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}
+
+// VPCRouterSiteToSiteIPsecVPNIKE サイト間VPNのIKE設定値
+type VPCRouterSiteToSiteIPsecVPNIKE struct {
+	Lifetime int // ISAKMP SAの寿命
+	DPD      VPCRouterSiteToSiteIPsecVPNIKEDPD
+}
+
+// VPCRouterSiteToSiteIPsecVPNIKEDPD サイト間VPNのIKE設定値 - DPD
+type VPCRouterSiteToSiteIPsecVPNIKEDPD struct {
+	Interval int // IKEキープアライブ(DPD) インターバル
+	Timeout  int // IKEキープアライブ(DPD) タイムアウト
+}
+
+// VPCRouterSiteToSiteIPsecVPNESP サイト間VPNのESP設定値
+type VPCRouterSiteToSiteIPsecVPNESP struct {
+	Lifetime int // IPsec SAの寿命
 }
 
 // VPCRouterStaticRoutes スタティックルート

--- a/test/vpc_router_op_test.go
+++ b/test/vpc_router_op_test.go
@@ -361,13 +361,25 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 								Password: "password1",
 							},
 						},
-						SiteToSiteIPsecVPN: []*iaas.VPCRouterSiteToSiteIPsecVPN{
-							{
-								Peer:            "1.2.3.4",
-								PreSharedSecret: "presharedsecret",
-								RemoteID:        "1.2.3.4",
-								Routes:          []string{"10.0.0.0/24"},
-								LocalPrefix:     []string{"192.168.2.0/24"},
+						SiteToSiteIPsecVPN: &iaas.VPCRouterSiteToSiteIPsecVPN{
+							Config: []*iaas.VPCRouterSiteToSiteIPsecVPNConfig{
+								{
+									Peer:            "1.2.3.4",
+									PreSharedSecret: "presharedsecret",
+									RemoteID:        "1.2.3.4",
+									Routes:          []string{"10.0.0.0/24"},
+									LocalPrefix:     []string{"192.168.2.0/24"},
+								},
+							},
+							IKE: &iaas.VPCRouterSiteToSiteIPsecVPNIKE{
+								Lifetime: 28801,
+								DPD: &iaas.VPCRouterSiteToSiteIPsecVPNIKEDPD{
+									Interval: 16,
+									Timeout:  31,
+								},
+							},
+							ESP: &iaas.VPCRouterSiteToSiteIPsecVPNESP{
+								Lifetime: 1801,
 							},
 						},
 						StaticRoute: []*iaas.VPCRouterStaticRoute{

--- a/zz_models.go
+++ b/zz_models.go
@@ -28133,7 +28133,7 @@ type VPCRouterSetting struct {
 	WireGuard                 *VPCRouterWireGuard            `mapconv:"Router.WireGuard.Config,omitempty,recursive"`
 	WireGuardEnabled          types.StringFlag               `mapconv:"Router.WireGuard.Enabled,omitempty"`
 	RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
-	SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
+	SiteToSiteIPsecVPN        *VPCRouterSiteToSiteIPsecVPN   `mapconv:"Router.SiteToSiteIPsecVPN,omitempty,recursive"`
 	StaticRoute               []*VPCRouterStaticRoute        `mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
 	SyslogHost                string                         `mapconv:"Router.SyslogHost"`
 	ScheduledMaintenance      *VPCRouterScheduledMaintenance `mapconv:"Router.ScheduledMaintenance,omitempty,recursive"`
@@ -28158,7 +28158,7 @@ func (o *VPCRouterSetting) setDefaults() interface{} {
 		WireGuard                 *VPCRouterWireGuard            `mapconv:"Router.WireGuard.Config,omitempty,recursive"`
 		WireGuardEnabled          types.StringFlag               `mapconv:"Router.WireGuard.Enabled,omitempty"`
 		RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
-		SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
+		SiteToSiteIPsecVPN        *VPCRouterSiteToSiteIPsecVPN   `mapconv:"Router.SiteToSiteIPsecVPN,omitempty,recursive"`
 		StaticRoute               []*VPCRouterStaticRoute        `mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
 		SyslogHost                string                         `mapconv:"Router.SyslogHost"`
 		ScheduledMaintenance      *VPCRouterScheduledMaintenance `mapconv:"Router.ScheduledMaintenance,omitempty,recursive"`
@@ -28347,12 +28347,12 @@ func (o *VPCRouterSetting) SetRemoteAccessUsers(v []*VPCRouterRemoteAccessUser) 
 }
 
 // GetSiteToSiteIPsecVPN returns value of SiteToSiteIPsecVPN
-func (o *VPCRouterSetting) GetSiteToSiteIPsecVPN() []*VPCRouterSiteToSiteIPsecVPN {
+func (o *VPCRouterSetting) GetSiteToSiteIPsecVPN() *VPCRouterSiteToSiteIPsecVPN {
 	return o.SiteToSiteIPsecVPN
 }
 
 // SetSiteToSiteIPsecVPN sets value to SiteToSiteIPsecVPN
-func (o *VPCRouterSetting) SetSiteToSiteIPsecVPN(v []*VPCRouterSiteToSiteIPsecVPN) {
+func (o *VPCRouterSetting) SetSiteToSiteIPsecVPN(v *VPCRouterSiteToSiteIPsecVPN) {
 	o.SiteToSiteIPsecVPN = v
 }
 
@@ -29159,6 +29159,60 @@ func (o *VPCRouterRemoteAccessUser) SetPassword(v string) {
 
 // VPCRouterSiteToSiteIPsecVPN represents API parameter/response structure
 type VPCRouterSiteToSiteIPsecVPN struct {
+	Config []*VPCRouterSiteToSiteIPsecVPNConfig `mapconv:"[]Config,omitempty,recursive"`
+	IKE    *VPCRouterSiteToSiteIPsecVPNIKE      `mapconv:",omitempty,recursive"`
+	ESP    *VPCRouterSiteToSiteIPsecVPNESP      `mapconv:",omitempty,recursive"`
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *VPCRouterSiteToSiteIPsecVPN) setDefaults() interface{} {
+	return &struct {
+		Config []*VPCRouterSiteToSiteIPsecVPNConfig `mapconv:"[]Config,omitempty,recursive"`
+		IKE    *VPCRouterSiteToSiteIPsecVPNIKE      `mapconv:",omitempty,recursive"`
+		ESP    *VPCRouterSiteToSiteIPsecVPNESP      `mapconv:",omitempty,recursive"`
+	}{
+		Config: o.GetConfig(),
+		IKE:    o.GetIKE(),
+		ESP:    o.GetESP(),
+	}
+}
+
+// GetConfig returns value of Config
+func (o *VPCRouterSiteToSiteIPsecVPN) GetConfig() []*VPCRouterSiteToSiteIPsecVPNConfig {
+	return o.Config
+}
+
+// SetConfig sets value to Config
+func (o *VPCRouterSiteToSiteIPsecVPN) SetConfig(v []*VPCRouterSiteToSiteIPsecVPNConfig) {
+	o.Config = v
+}
+
+// GetIKE returns value of IKE
+func (o *VPCRouterSiteToSiteIPsecVPN) GetIKE() *VPCRouterSiteToSiteIPsecVPNIKE {
+	return o.IKE
+}
+
+// SetIKE sets value to IKE
+func (o *VPCRouterSiteToSiteIPsecVPN) SetIKE(v *VPCRouterSiteToSiteIPsecVPNIKE) {
+	o.IKE = v
+}
+
+// GetESP returns value of ESP
+func (o *VPCRouterSiteToSiteIPsecVPN) GetESP() *VPCRouterSiteToSiteIPsecVPNESP {
+	return o.ESP
+}
+
+// SetESP sets value to ESP
+func (o *VPCRouterSiteToSiteIPsecVPN) SetESP(v *VPCRouterSiteToSiteIPsecVPNESP) {
+	o.ESP = v
+}
+
+/*************************************************
+* VPCRouterSiteToSiteIPsecVPNConfig
+*************************************************/
+
+// VPCRouterSiteToSiteIPsecVPNConfig represents API parameter/response structure
+type VPCRouterSiteToSiteIPsecVPNConfig struct {
 	Peer            string
 	PreSharedSecret string
 	RemoteID        string
@@ -29167,7 +29221,7 @@ type VPCRouterSiteToSiteIPsecVPN struct {
 }
 
 // setDefaults implements iaas.argumentDefaulter
-func (o *VPCRouterSiteToSiteIPsecVPN) setDefaults() interface{} {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) setDefaults() interface{} {
 	return &struct {
 		Peer            string
 		PreSharedSecret string
@@ -29184,53 +29238,163 @@ func (o *VPCRouterSiteToSiteIPsecVPN) setDefaults() interface{} {
 }
 
 // GetPeer returns value of Peer
-func (o *VPCRouterSiteToSiteIPsecVPN) GetPeer() string {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) GetPeer() string {
 	return o.Peer
 }
 
 // SetPeer sets value to Peer
-func (o *VPCRouterSiteToSiteIPsecVPN) SetPeer(v string) {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) SetPeer(v string) {
 	o.Peer = v
 }
 
 // GetPreSharedSecret returns value of PreSharedSecret
-func (o *VPCRouterSiteToSiteIPsecVPN) GetPreSharedSecret() string {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) GetPreSharedSecret() string {
 	return o.PreSharedSecret
 }
 
 // SetPreSharedSecret sets value to PreSharedSecret
-func (o *VPCRouterSiteToSiteIPsecVPN) SetPreSharedSecret(v string) {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) SetPreSharedSecret(v string) {
 	o.PreSharedSecret = v
 }
 
 // GetRemoteID returns value of RemoteID
-func (o *VPCRouterSiteToSiteIPsecVPN) GetRemoteID() string {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) GetRemoteID() string {
 	return o.RemoteID
 }
 
 // SetRemoteID sets value to RemoteID
-func (o *VPCRouterSiteToSiteIPsecVPN) SetRemoteID(v string) {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) SetRemoteID(v string) {
 	o.RemoteID = v
 }
 
 // GetRoutes returns value of Routes
-func (o *VPCRouterSiteToSiteIPsecVPN) GetRoutes() []string {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) GetRoutes() []string {
 	return o.Routes
 }
 
 // SetRoutes sets value to Routes
-func (o *VPCRouterSiteToSiteIPsecVPN) SetRoutes(v []string) {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) SetRoutes(v []string) {
 	o.Routes = v
 }
 
 // GetLocalPrefix returns value of LocalPrefix
-func (o *VPCRouterSiteToSiteIPsecVPN) GetLocalPrefix() []string {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) GetLocalPrefix() []string {
 	return o.LocalPrefix
 }
 
 // SetLocalPrefix sets value to LocalPrefix
-func (o *VPCRouterSiteToSiteIPsecVPN) SetLocalPrefix(v []string) {
+func (o *VPCRouterSiteToSiteIPsecVPNConfig) SetLocalPrefix(v []string) {
 	o.LocalPrefix = v
+}
+
+/*************************************************
+* VPCRouterSiteToSiteIPsecVPNIKE
+*************************************************/
+
+// VPCRouterSiteToSiteIPsecVPNIKE represents API parameter/response structure
+type VPCRouterSiteToSiteIPsecVPNIKE struct {
+	Lifetime int
+	DPD      *VPCRouterSiteToSiteIPsecVPNIKEDPD `mapconv:",omitempty,recursive"`
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *VPCRouterSiteToSiteIPsecVPNIKE) setDefaults() interface{} {
+	return &struct {
+		Lifetime int
+		DPD      *VPCRouterSiteToSiteIPsecVPNIKEDPD `mapconv:",omitempty,recursive"`
+	}{
+		Lifetime: o.GetLifetime(),
+		DPD:      o.GetDPD(),
+	}
+}
+
+// GetLifetime returns value of Lifetime
+func (o *VPCRouterSiteToSiteIPsecVPNIKE) GetLifetime() int {
+	return o.Lifetime
+}
+
+// SetLifetime sets value to Lifetime
+func (o *VPCRouterSiteToSiteIPsecVPNIKE) SetLifetime(v int) {
+	o.Lifetime = v
+}
+
+// GetDPD returns value of DPD
+func (o *VPCRouterSiteToSiteIPsecVPNIKE) GetDPD() *VPCRouterSiteToSiteIPsecVPNIKEDPD {
+	return o.DPD
+}
+
+// SetDPD sets value to DPD
+func (o *VPCRouterSiteToSiteIPsecVPNIKE) SetDPD(v *VPCRouterSiteToSiteIPsecVPNIKEDPD) {
+	o.DPD = v
+}
+
+/*************************************************
+* VPCRouterSiteToSiteIPsecVPNIKEDPD
+*************************************************/
+
+// VPCRouterSiteToSiteIPsecVPNIKEDPD represents API parameter/response structure
+type VPCRouterSiteToSiteIPsecVPNIKEDPD struct {
+	Interval int
+	Timeout  int
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *VPCRouterSiteToSiteIPsecVPNIKEDPD) setDefaults() interface{} {
+	return &struct {
+		Interval int
+		Timeout  int
+	}{
+		Interval: o.GetInterval(),
+		Timeout:  o.GetTimeout(),
+	}
+}
+
+// GetInterval returns value of Interval
+func (o *VPCRouterSiteToSiteIPsecVPNIKEDPD) GetInterval() int {
+	return o.Interval
+}
+
+// SetInterval sets value to Interval
+func (o *VPCRouterSiteToSiteIPsecVPNIKEDPD) SetInterval(v int) {
+	o.Interval = v
+}
+
+// GetTimeout returns value of Timeout
+func (o *VPCRouterSiteToSiteIPsecVPNIKEDPD) GetTimeout() int {
+	return o.Timeout
+}
+
+// SetTimeout sets value to Timeout
+func (o *VPCRouterSiteToSiteIPsecVPNIKEDPD) SetTimeout(v int) {
+	o.Timeout = v
+}
+
+/*************************************************
+* VPCRouterSiteToSiteIPsecVPNESP
+*************************************************/
+
+// VPCRouterSiteToSiteIPsecVPNESP represents API parameter/response structure
+type VPCRouterSiteToSiteIPsecVPNESP struct {
+	Lifetime int
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *VPCRouterSiteToSiteIPsecVPNESP) setDefaults() interface{} {
+	return &struct {
+		Lifetime int
+	}{
+		Lifetime: o.GetLifetime(),
+	}
+}
+
+// GetLifetime returns value of Lifetime
+func (o *VPCRouterSiteToSiteIPsecVPNESP) GetLifetime() int {
+	return o.Lifetime
+}
+
+// SetLifetime sets value to Lifetime
+func (o *VPCRouterSiteToSiteIPsecVPNESP) SetLifetime(v int) {
+	o.Lifetime = v
 }
 
 /*************************************************


### PR DESCRIPTION
closes #33 

Note: breaking-changeとなるためVPCルータのSettings.SiteToSiteIPsecVPNを利用していたクライアントは修正が必要。