### PR TITLE
query.FindArchiveByOSTypeでScopeを考慮するように修正

### DIFF
--- a/helper/query/archive_find_by_ostype_test.go
+++ b/helper/query/archive_find_by_ostype_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/ostype"
+	"github.com/sacloud/iaas-api-go/search"
 	"github.com/sacloud/iaas-api-go/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -105,4 +106,11 @@ func TestAccFindArchiveByOSType(t *testing.T) {
 			t.Logf("zone: %s ostype[%s] => {ID: %d, Name: %s}", zone, os, archive.ID, archive.Name)
 		}
 	}
+}
+
+func Test_filterByOSType(t *testing.T) {
+	filter, err := filterByOSType(ostype.CentOS)
+	require.NoError(t, err)
+	_, hasScopeCond := filter[search.Key("Scope")]
+	require.True(t, hasScopeCond)
 }


### PR DESCRIPTION
from: https://github.com/sacloud/terraform-provider-sakuracloud/issues/912

パブリックアーカイブと同じタグを持つアーカイブが存在した場合に意図したアーカイブ以外がヒットする場合があった問題を修正