### PR TITLE
query.FindArchiveByOSTypeの問題を修正

### DIFF
--- a/fake/functions.go
+++ b/fake/functions.go
@@ -146,7 +146,7 @@ FILTER_APPLY_LOOP:
 							}
 						case "Scope":
 							if v, ok := target.(accessor.Scope); ok {
-								value = v.GetScope()
+								value = v.GetScope().String()
 							}
 						case "Class":
 							if v, ok := target.(accessor.Class); ok {

--- a/helper/query/archive_find_by_ostype.go
+++ b/helper/query/archive_find_by_ostype.go
@@ -20,15 +20,13 @@ import (
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/ostype"
-	"github.com/sacloud/iaas-api-go/search"
-	"github.com/sacloud/iaas-api-go/types"
 )
 
 // FindArchiveByOSType OS種別ごとの最新安定板のアーカイブを取得
 func FindArchiveByOSType(ctx context.Context, api ArchiveFinder, zone string, os ostype.ArchiveOSType) (*iaas.Archive, error) {
-	filter, err := filterByOSType(os)
-	if err != nil {
-		return nil, err
+	filter, ok := ostype.ArchiveCriteria[os]
+	if !ok {
+		return nil, fmt.Errorf("unsupported ostype.ArchiveOSType: %v", os)
 	}
 
 	searched, err := api.Find(ctx, zone, &iaas.FindCondition{Filter: filter})
@@ -39,13 +37,4 @@ func FindArchiveByOSType(ctx context.Context, api ArchiveFinder, zone string, os
 		return nil, fmt.Errorf("archive not found with ostype.ArchiveOSType: %v", os)
 	}
 	return searched.Archives[0], nil
-}
-
-func filterByOSType(os ostype.ArchiveOSType) (search.Filter, error) {
-	filter, ok := ostype.ArchiveCriteria[os]
-	if !ok {
-		return nil, fmt.Errorf("unsupported ostype.ArchiveOSType: %v", os)
-	}
-	filter[search.Key("Scope")] = search.ExactMatch(types.Scopes.Shared.String())
-	return filter, nil
 }

--- a/helper/query/archive_find_by_ostype_test.go
+++ b/helper/query/archive_find_by_ostype_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/ostype"
-	"github.com/sacloud/iaas-api-go/search"
 	"github.com/sacloud/iaas-api-go/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -106,11 +105,4 @@ func TestAccFindArchiveByOSType(t *testing.T) {
 			t.Logf("zone: %s ostype[%s] => {ID: %d, Name: %s}", zone, os, archive.ID, archive.Name)
 		}
 	}
-}
-
-func Test_filterByOSType(t *testing.T) {
-	filter, err := filterByOSType(ostype.CentOS)
-	require.NoError(t, err)
-	_, hasScopeCond := filter[search.Key("Scope")]
-	require.True(t, hasScopeCond)
 }

--- a/ostype/filter_criteria.go
+++ b/ostype/filter_criteria.go
@@ -17,56 +17,73 @@ package ostype
 import (
 	"github.com/sacloud/iaas-api-go/search"
 	"github.com/sacloud/iaas-api-go/search/keys"
+	"github.com/sacloud/iaas-api-go/types"
 )
 
 // ArchiveCriteria OSTypeごとのアーカイブ検索条件
 var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 	CentOS: {
-		search.Key(keys.Tags): search.TagsAndEqual("distro-centos"),
+		search.Key(keys.Tags):  search.TagsAndEqual("distro-centos"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	CentOS8Stream: {
-		search.Key(keys.Tags): search.TagsAndEqual("distro-ver-8-stream", "distro-centos"),
+		search.Key(keys.Tags):  search.TagsAndEqual("distro-ver-8-stream", "distro-centos"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	CentOS7: {
-		search.Key(keys.Tags): search.TagsAndEqual("centos-7-latest"),
+		search.Key(keys.Tags):  search.TagsAndEqual("centos-7-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	AlmaLinux: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-alma"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-alma"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	RockyLinux: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-rocky"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-rocky"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	MiracleLinux: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-miracle"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-miracle"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Ubuntu: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-ubuntu"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-ubuntu"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Ubuntu2204: {
-		search.Key(keys.Tags): search.TagsAndEqual("ubuntu-22.04-latest"),
+		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-22.04-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Ubuntu2004: {
-		search.Key(keys.Tags): search.TagsAndEqual("ubuntu-20.04-latest"),
+		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-20.04-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Ubuntu1804: {
-		search.Key(keys.Tags): search.TagsAndEqual("ubuntu-18.04-latest"),
+		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-18.04-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Debian: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-debian"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-debian"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Debian10: {
-		search.Key(keys.Tags): search.TagsAndEqual("debian-10-latest"),
+		search.Key(keys.Tags):  search.TagsAndEqual("debian-10-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Debian11: {
-		search.Key(keys.Tags): search.TagsAndEqual("debian-11-latest"),
+		search.Key(keys.Tags):  search.TagsAndEqual("debian-11-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	RancherOS: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-rancheros"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-rancheros"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	K3OS: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-k3os"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-k3os"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Kusanagi: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "pkg-kusanagi"),
+		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "pkg-kusanagi"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 }


### PR DESCRIPTION
closes #83 

- DATA RACEを防ぐために実行時にostype.ArchiveCriteriaを変更しないようにする
- FakeドライバーでScopeの比較がうまくいかない問題を修正するために比較前に型を揃える対応