### PR TITLE
VPCRouterのTypeStringFlag項目からomitemptyを除去

### DIFF
--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -802,7 +802,7 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "InternetConnectionEnabled",
 				Type: meta.TypeStringFlag,
 				Tags: &dsl.FieldTags{
-					MapConv: "Router.InternetConnection.Enabled,omitempty",
+					MapConv: "Router.InternetConnection.Enabled",
 				},
 			},
 			{
@@ -865,7 +865,7 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "PPTPServerEnabled",
 				Type: meta.TypeStringFlag,
 				Tags: &dsl.FieldTags{
-					MapConv: "Router.PPTPServer.Enabled,omitempty",
+					MapConv: "Router.PPTPServer.Enabled",
 				},
 			},
 			{
@@ -879,7 +879,7 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "L2TPIPsecServerEnabled",
 				Type: meta.TypeStringFlag,
 				Tags: &dsl.FieldTags{
-					MapConv: "Router.L2TPIPsecServer.Enabled,omitempty",
+					MapConv: "Router.L2TPIPsecServer.Enabled",
 				},
 			},
 			{
@@ -893,7 +893,7 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "WireGuardEnabled",
 				Type: meta.TypeStringFlag,
 				Tags: &dsl.FieldTags{
-					MapConv: "Router.WireGuard.Enabled,omitempty",
+					MapConv: "Router.WireGuard.Enabled",
 				},
 			},
 			{

--- a/test/server_op_test.go
+++ b/test/server_op_test.go
@@ -74,7 +74,7 @@ func TestServerOp_CRUD(t *testing.T) {
 					// find cdrom
 					searched, err := cdOp.Find(ctx, testZone, &iaas.FindCondition{
 						Filter: search.Filter{
-							search.Key(keys.Scope): types.Scopes.Shared,
+							search.Key(keys.Scope): types.Scopes.Shared.String(),
 						},
 						Count: 1,
 					})

--- a/test/vpc_router_op_test.go
+++ b/test/vpc_router_op_test.go
@@ -89,23 +89,7 @@ var (
 		Name:        testutil.ResourceName("vpc-router"),
 		Description: "desc",
 		Tags:        []string{"tag1", "tag2"},
-		Settings: &iaas.VPCRouterSetting{
-			InternetConnectionEnabled: true,
-			Firewall: []*iaas.VPCRouterFirewall{
-				{
-					Receive: []*iaas.VPCRouterFirewallRule{
-						{
-							Protocol: types.Protocols.IP,
-							Action:   types.Actions.Deny,
-						},
-					},
-				},
-			},
-			ScheduledMaintenance: &iaas.VPCRouterScheduledMaintenance{
-				DayOfWeek: 1,
-				Hour:      2,
-			},
-		},
+		Settings:    &iaas.VPCRouterSetting{},
 	}
 	createVPCRouterExpected = &iaas.VPCRouter{
 		Class:          "vpcrouter",

--- a/transformer_test.go
+++ b/transformer_test.go
@@ -388,6 +388,9 @@ func TestVPCRouterOp_transformCreateArgs(t *testing.T) {
 					},
 					Settings: &naked.VPCRouterSettings{
 						Router: &naked.VPCRouterSetting{
+							InternetConnection: &naked.VPCRouterInternetConnection{},
+							PPTPServer:         &naked.VPCRouterPPTPServer{},
+							L2TPIPsecServer:    &naked.VPCRouterL2TPIPsecServer{},
 							WireGuard: &naked.VPCRouterWireGuard{
 								Config: &naked.VPCRouterWireGuardConfig{
 									IPAddress: "192.168.1.1",

--- a/zz_models.go
+++ b/zz_models.go
@@ -28118,7 +28118,7 @@ func (o *VPCRouter) SetZoneID(v types.ID) {
 // VPCRouterSetting represents API parameter/response structure
 type VPCRouterSetting struct {
 	VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
-	InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled,omitempty"`
+	InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled"`
 	Interfaces                []*VPCRouterInterfaceSetting   `mapconv:"Router.[]Interfaces,omitempty,recursive"`
 	StaticNAT                 []*VPCRouterStaticNAT          `mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
 	PortForwarding            []*VPCRouterPortForwarding     `mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
@@ -28127,11 +28127,11 @@ type VPCRouterSetting struct {
 	DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
 	DNSForwarding             *VPCRouterDNSForwarding        `mapconv:"Router.DNSForwarding,omitempty,recursive"`
 	PPTPServer                *VPCRouterPPTPServer           `mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
-	PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled,omitempty"`
+	PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled"`
 	L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
-	L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
+	L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled"`
 	WireGuard                 *VPCRouterWireGuard            `mapconv:"Router.WireGuard.Config,omitempty,recursive"`
-	WireGuardEnabled          types.StringFlag               `mapconv:"Router.WireGuard.Enabled,omitempty"`
+	WireGuardEnabled          types.StringFlag               `mapconv:"Router.WireGuard.Enabled"`
 	RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
 	SiteToSiteIPsecVPN        *VPCRouterSiteToSiteIPsecVPN   `mapconv:"Router.SiteToSiteIPsecVPN,omitempty,recursive"`
 	StaticRoute               []*VPCRouterStaticRoute        `mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
@@ -28143,7 +28143,7 @@ type VPCRouterSetting struct {
 func (o *VPCRouterSetting) setDefaults() interface{} {
 	return &struct {
 		VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
-		InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled,omitempty"`
+		InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled"`
 		Interfaces                []*VPCRouterInterfaceSetting   `mapconv:"Router.[]Interfaces,omitempty,recursive"`
 		StaticNAT                 []*VPCRouterStaticNAT          `mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
 		PortForwarding            []*VPCRouterPortForwarding     `mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
@@ -28152,11 +28152,11 @@ func (o *VPCRouterSetting) setDefaults() interface{} {
 		DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
 		DNSForwarding             *VPCRouterDNSForwarding        `mapconv:"Router.DNSForwarding,omitempty,recursive"`
 		PPTPServer                *VPCRouterPPTPServer           `mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
-		PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled,omitempty"`
+		PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled"`
 		L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
-		L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
+		L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled"`
 		WireGuard                 *VPCRouterWireGuard            `mapconv:"Router.WireGuard.Config,omitempty,recursive"`
-		WireGuardEnabled          types.StringFlag               `mapconv:"Router.WireGuard.Enabled,omitempty"`
+		WireGuardEnabled          types.StringFlag               `mapconv:"Router.WireGuard.Enabled"`
 		RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
 		SiteToSiteIPsecVPN        *VPCRouterSiteToSiteIPsecVPN   `mapconv:"Router.SiteToSiteIPsecVPN,omitempty,recursive"`
 		StaticRoute               []*VPCRouterStaticRoute        `mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`


### PR DESCRIPTION
omitemptyが付いていると他にパラメータがない場合にエラーとなる。また、True->Falseへの変更も行えない。
このためomitemptyを除去し常にリクエストに含めるようにする