### PR TITLE
fix: フィールド名修正 -> BackupSpanWeekdays

### DIFF
--- a/internal/define/auto_backup.go
+++ b/internal/define/auto_backup.go
@@ -70,7 +70,7 @@ var (
 			fields.ModifiedAt(),
 
 			// settings
-			fields.AutoBackupBackupSpanWeekDays(),
+			fields.AutoBackupBackupSpanWeekdays(),
 			fields.AutoBackupMaximumNumberOfArchives(),
 			fields.SettingsHash(),
 
@@ -109,7 +109,7 @@ var (
 			fields.AutoBackupDiskID(),
 
 			// backup setting
-			fields.AutoBackupBackupSpanWeekDays(),
+			fields.AutoBackupBackupSpanWeekdays(),
 			fields.AutoBackupMaximumNumberOfArchives(),
 
 			// common fields
@@ -141,7 +141,7 @@ var (
 			fields.IconID(),
 
 			// backup setting
-			fields.AutoBackupBackupSpanWeekDays(),
+			fields.AutoBackupBackupSpanWeekdays(),
 			fields.AutoBackupMaximumNumberOfArchives(),
 			// settings hash
 			fields.SettingsHash(),
@@ -163,7 +163,7 @@ var (
 		},
 		Fields: []*dsl.FieldDesc{
 			// backup setting
-			fields.AutoBackupBackupSpanWeekDays(),
+			fields.AutoBackupBackupSpanWeekdays(),
 			fields.AutoBackupMaximumNumberOfArchives(),
 			// settings hash
 			fields.SettingsHash(),

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -945,12 +945,12 @@ func (f *fieldsDef) GSLBSorryServer() *dsl.FieldDesc {
 	}
 }
 
-func (f *fieldsDef) AutoBackupBackupSpanWeekDays() *dsl.FieldDesc {
+func (f *fieldsDef) AutoBackupBackupSpanWeekdays() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
-		Name: "DaysOfTheWeek",
+		Name: "BackupSpanWeekdays",
 		Type: meta.TypeBackupSpanWeekdays,
 		Tags: &dsl.FieldTags{
-			MapConv: "Settings.Autobackup.DaysOfTheWeek",
+			MapConv: "Settings.Autobackup.BackupSpanWeekdays",
 		},
 	}
 }

--- a/zz_models.go
+++ b/zz_models.go
@@ -1547,7 +1547,7 @@ type AutoBackup struct {
 	IconID                  types.ID `mapconv:"Icon.ID"`
 	CreatedAt               time.Time
 	ModifiedAt              time.Time
-	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 	MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 	SettingsHash            string                `json:",omitempty" mapconv:",omitempty"`
 	DiskID                  types.ID              `mapconv:"Status.DiskID"`
@@ -1567,7 +1567,7 @@ func (o *AutoBackup) setDefaults() interface{} {
 		IconID                  types.ID `mapconv:"Icon.ID"`
 		CreatedAt               time.Time
 		ModifiedAt              time.Time
-		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 		MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 		SettingsHash            string                `json:",omitempty" mapconv:",omitempty"`
 		DiskID                  types.ID              `mapconv:"Status.DiskID"`
@@ -1790,7 +1790,7 @@ func (o *AutoBackup) SetZoneName(v string) {
 // AutoBackupCreateRequest represents API parameter/response structure
 type AutoBackupCreateRequest struct {
 	DiskID                  types.ID              `mapconv:"Status.DiskID"`
-	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 	MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 	Name                    string
 	Description             string
@@ -1802,7 +1802,7 @@ type AutoBackupCreateRequest struct {
 func (o *AutoBackupCreateRequest) setDefaults() interface{} {
 	return &struct {
 		DiskID                  types.ID              `mapconv:"Status.DiskID"`
-		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 		MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 		Name                    string
 		Description             string
@@ -1923,7 +1923,7 @@ type AutoBackupUpdateRequest struct {
 	Description             string
 	Tags                    types.Tags
 	IconID                  types.ID              `mapconv:"Icon.ID"`
-	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 	MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 	SettingsHash            string                `json:",omitempty" mapconv:",omitempty"`
 }
@@ -1935,7 +1935,7 @@ func (o *AutoBackupUpdateRequest) setDefaults() interface{} {
 		Description             string
 		Tags                    types.Tags
 		IconID                  types.ID              `mapconv:"Icon.ID"`
-		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 		MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 		SettingsHash            string                `json:",omitempty" mapconv:",omitempty"`
 		BackupSpanType          types.EBackupSpanType `mapconv:"Settings.Autobackup.BackupSpanType"`
@@ -2047,7 +2047,7 @@ func (o *AutoBackupUpdateRequest) SetSettingsHash(v string) {
 
 // AutoBackupUpdateSettingsRequest represents API parameter/response structure
 type AutoBackupUpdateSettingsRequest struct {
-	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+	BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 	MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 	SettingsHash            string                `json:",omitempty" mapconv:",omitempty"`
 }
@@ -2055,7 +2055,7 @@ type AutoBackupUpdateSettingsRequest struct {
 // setDefaults implements iaas.argumentDefaulter
 func (o *AutoBackupUpdateSettingsRequest) setDefaults() interface{} {
 	return &struct {
-		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.DaysOfTheWeek"`
+		BackupSpanWeekdays      []types.EDayOfTheWeek `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 		MaximumNumberOfArchives int                   `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
 		SettingsHash            string                `json:",omitempty" mapconv:",omitempty"`
 		BackupSpanType          types.EBackupSpanType `mapconv:"Settings.Autobackup.BackupSpanType"`


### PR DESCRIPTION
#104 のデグレ
#104でフィールド名を修正した際に誤って対象外のフィールド(BackupSpanWeekdays)も変更した問題の修正