### PR TITLE
doc: using `types.Scopes.Shared` instead of raw string literal

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -74,7 +74,7 @@ func Example_serverCRUD() {
 		MemoryMB:             1 * size.GiB,
 		ServerPlanCommitment: types.Commitments.Standard,
 		ServerPlanGeneration: types.PlanGenerations.Default,
-		ConnectedSwitches:    []*iaas.ConnectedSwitch{{Scope: "shared"}},
+		ConnectedSwitches:    []*iaas.ConnectedSwitch{{Scope: types.Scopes.Shared}},
 		InterfaceDriver:      types.InterfaceDrivers.VirtIO,
 		Name:                 "libsacloud-example",
 		Description:          "description",


### PR DESCRIPTION
Go Exampleで `Scope: "shared"` のようにハードコードを利用していますが、
`iaas-api-go/types` で `Scopes.Shared` を提供しているので、そちらを利用するようにしました。

In example_test.go, the serverCRUD test uses a hard-coding like `Scope: "shared"`.
But the `iaas-api-go/types` package provides the constant `types.Scopes.Shared`.
So this PR replaces the hard-coding to the constant, for avoiding the confusion.

Signed-off-by: Drumato <drumato43@gmail.com>