### PR TITLE
ostype更新

### DIFF
--- a/ostype/archive_ostype.go
+++ b/ostype/archive_ostype.go
@@ -31,10 +31,22 @@ const (
 
 	// AlmaLinux OS種別: Alma Linux
 	AlmaLinux
+	// AlmaLinux9 OS種別: Alma Linux9
+	AlmaLinux9
+	// AlmaLinux8 OS種別: Alma Linux8
+	AlmaLinux8
+
 	// RockyLinux OS種別: Rocky Linux
 	RockyLinux
+	// RockyLinux9 OS種別: Rocky Linux9
+	RockyLinux9
+	// RockyLinux8 OS種別: Rocky Linux8
+	RockyLinux8
+
 	// MiracleLinux OS種別: MIRACLE LINUX
 	MiracleLinux
+	// MiracleLinux8 OS種別: MIRACLE LINUX8
+	MiracleLinux8
 
 	// Ubuntu OS種別:Ubuntu
 	Ubuntu
@@ -61,8 +73,13 @@ var ArchiveOSTypes = []ArchiveOSType{
 	CentOS,
 	CentOS7,
 	AlmaLinux,
+	AlmaLinux9,
+	AlmaLinux8,
 	RockyLinux,
+	RockyLinux9,
+	RockyLinux8,
 	MiracleLinux,
+	MiracleLinux8,
 	Ubuntu,
 	Ubuntu2204,
 	Ubuntu2004,
@@ -76,7 +93,9 @@ var ArchiveOSTypes = []ArchiveOSType{
 // OSTypeShortNames OSTypeとして利用できる文字列のリスト
 var OSTypeShortNames = []string{
 	"centos", "centos7",
-	"almalinux", "rockylinux", "miracle", "miraclelinux",
+	"almalinux", "almalinux9", "almalinux8",
+	"rockylinux", "rockylinux9", "rockylinux8",
+	"miracle", "miraclelinux", "miracle8", "miraclelinux8",
 	"ubuntu", "ubuntu2204", "ubuntu2004", "ubuntu1804",
 	"debian", "debian10", "debian11",
 	"kusanagi",
@@ -86,7 +105,9 @@ var OSTypeShortNames = []string{
 func (o ArchiveOSType) IsSupportDiskEdit() bool {
 	switch o {
 	case CentOS, CentOS7,
-		AlmaLinux, RockyLinux, MiracleLinux,
+		AlmaLinux, AlmaLinux9, AlmaLinux8,
+		RockyLinux, RockyLinux9, RockyLinux8,
+		MiracleLinux, MiracleLinux8,
 		Ubuntu, Ubuntu2204, Ubuntu2004, Ubuntu1804,
 		Debian, Debian10, Debian11,
 		Kusanagi:
@@ -105,10 +126,20 @@ func StrToOSType(osType string) ArchiveOSType {
 		return CentOS7
 	case "almalinux":
 		return AlmaLinux
+	case "almalinux9":
+		return AlmaLinux9
+	case "almalinux8":
+		return AlmaLinux8
 	case "rockylinux":
 		return RockyLinux
+	case "rockylinux9":
+		return RockyLinux9
+	case "rockylinux8":
+		return RockyLinux8
 	case "miracle", "miraclelinux":
 		return MiracleLinux
+	case "miracle8", "miraclelinux8":
+		return MiracleLinux8
 	case "ubuntu":
 		return Ubuntu
 	case "ubuntu2204":

--- a/ostype/archive_ostype.go
+++ b/ostype/archive_ostype.go
@@ -26,8 +26,6 @@ const (
 
 	// CentOS OS種別:CentOS
 	CentOS
-	// CentOS8Stream OS種別:CentOS8Stream
-	CentOS8Stream
 	// CentOS7 OS種別:CentOS7
 	CentOS7
 
@@ -54,11 +52,6 @@ const (
 	// Debian11 OS種別:Debian11
 	Debian11
 
-	// RancherOS OS種別:RancherOS
-	RancherOS
-	// K3OS OS種別: k3OS
-	K3OS
-
 	// Kusanagi OS種別:Kusanagi(CentOS)
 	Kusanagi
 )
@@ -66,7 +59,6 @@ const (
 // ArchiveOSTypes アーカイブ種別のリスト
 var ArchiveOSTypes = []ArchiveOSType{
 	CentOS,
-	CentOS8Stream,
 	CentOS7,
 	AlmaLinux,
 	RockyLinux,
@@ -78,28 +70,26 @@ var ArchiveOSTypes = []ArchiveOSType{
 	Debian,
 	Debian10,
 	Debian11,
-	RancherOS,
-	K3OS,
 	Kusanagi,
 }
 
 // OSTypeShortNames OSTypeとして利用できる文字列のリスト
 var OSTypeShortNames = []string{
-	"centos", "centos8stream", "centos7",
+	"centos", "centos7",
 	"almalinux", "rockylinux", "miracle", "miraclelinux",
 	"ubuntu", "ubuntu2204", "ubuntu2004", "ubuntu1804",
 	"debian", "debian10", "debian11",
-	"rancheros", "k3os", "kusanagi",
+	"kusanagi",
 }
 
 // IsSupportDiskEdit ディスクの修正機能をフルサポートしているか(Windowsは一部サポートのためfalseを返す)
 func (o ArchiveOSType) IsSupportDiskEdit() bool {
 	switch o {
-	case CentOS, CentOS8Stream, CentOS7,
+	case CentOS, CentOS7,
 		AlmaLinux, RockyLinux, MiracleLinux,
 		Ubuntu, Ubuntu2204, Ubuntu2004, Ubuntu1804,
 		Debian, Debian10, Debian11,
-		RancherOS, K3OS, Kusanagi:
+		Kusanagi:
 		return true
 	default:
 		return false
@@ -111,8 +101,6 @@ func StrToOSType(osType string) ArchiveOSType {
 	switch osType {
 	case "centos":
 		return CentOS
-	case "centos8stream":
-		return CentOS8Stream
 	case "centos7":
 		return CentOS7
 	case "almalinux":
@@ -135,10 +123,6 @@ func StrToOSType(osType string) ArchiveOSType {
 		return Debian10
 	case "debian11":
 		return Debian11
-	case "rancheros":
-		return RancherOS
-	case "k3os":
-		return K3OS
 	case "kusanagi":
 		return Kusanagi
 	default:

--- a/ostype/archive_ostype_test.go
+++ b/ostype/archive_ostype_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestArchiveOSTypeDefinitions(t *testing.T) {
 	// OSTypeShortNamesへの追加忘れを防ぐ
-	require.Equal(t, len(OSTypeShortNames), len(ArchiveOSTypes)+1) // miracleのエイリアス分で+1
+	require.Equal(t, len(OSTypeShortNames), len(ArchiveOSTypes)+2) // miracleとmiracle8のエイリアス分で+2
 }

--- a/ostype/archiveostype_string.go
+++ b/ostype/archiveostype_string.go
@@ -26,21 +26,26 @@ func _() {
 	_ = x[CentOS-1]
 	_ = x[CentOS7-2]
 	_ = x[AlmaLinux-3]
-	_ = x[RockyLinux-4]
-	_ = x[MiracleLinux-5]
-	_ = x[Ubuntu-6]
-	_ = x[Ubuntu2204-7]
-	_ = x[Ubuntu2004-8]
-	_ = x[Ubuntu1804-9]
-	_ = x[Debian-10]
-	_ = x[Debian10-11]
-	_ = x[Debian11-12]
-	_ = x[Kusanagi-13]
+	_ = x[AlmaLinux9-4]
+	_ = x[AlmaLinux8-5]
+	_ = x[RockyLinux-6]
+	_ = x[RockyLinux9-7]
+	_ = x[RockyLinux8-8]
+	_ = x[MiracleLinux-9]
+	_ = x[MiracleLinux8-10]
+	_ = x[Ubuntu-11]
+	_ = x[Ubuntu2204-12]
+	_ = x[Ubuntu2004-13]
+	_ = x[Ubuntu1804-14]
+	_ = x[Debian-15]
+	_ = x[Debian10-16]
+	_ = x[Debian11-17]
+	_ = x[Kusanagi-18]
 }
 
-const _ArchiveOSType_name = "CustomCentOSCentOS7AlmaLinuxRockyLinuxMiracleLinuxUbuntuUbuntu2204Ubuntu2004Ubuntu1804DebianDebian10Debian11Kusanagi"
+const _ArchiveOSType_name = "CustomCentOSCentOS7AlmaLinuxAlmaLinux9AlmaLinux8RockyLinuxRockyLinux9RockyLinux8MiracleLinuxMiracleLinux8UbuntuUbuntu2204Ubuntu2004Ubuntu1804DebianDebian10Debian11Kusanagi"
 
-var _ArchiveOSType_index = [...]uint8{0, 6, 12, 19, 28, 38, 50, 56, 66, 76, 86, 92, 100, 108, 116}
+var _ArchiveOSType_index = [...]uint8{0, 6, 12, 19, 28, 38, 48, 58, 69, 80, 92, 105, 111, 121, 131, 141, 147, 155, 163, 171}
 
 func (i ArchiveOSType) String() string {
 	if i < 0 || i >= ArchiveOSType(len(_ArchiveOSType_index)-1) {

--- a/ostype/archiveostype_string.go
+++ b/ostype/archiveostype_string.go
@@ -24,26 +24,23 @@ func _() {
 	var x [1]struct{}
 	_ = x[Custom-0]
 	_ = x[CentOS-1]
-	_ = x[CentOS8Stream-2]
-	_ = x[CentOS7-3]
-	_ = x[AlmaLinux-4]
-	_ = x[RockyLinux-5]
-	_ = x[MiracleLinux-6]
-	_ = x[Ubuntu-7]
-	_ = x[Ubuntu2204-8]
-	_ = x[Ubuntu2004-9]
-	_ = x[Ubuntu1804-10]
-	_ = x[Debian-11]
-	_ = x[Debian10-12]
-	_ = x[Debian11-13]
-	_ = x[RancherOS-14]
-	_ = x[K3OS-15]
-	_ = x[Kusanagi-16]
+	_ = x[CentOS7-2]
+	_ = x[AlmaLinux-3]
+	_ = x[RockyLinux-4]
+	_ = x[MiracleLinux-5]
+	_ = x[Ubuntu-6]
+	_ = x[Ubuntu2204-7]
+	_ = x[Ubuntu2004-8]
+	_ = x[Ubuntu1804-9]
+	_ = x[Debian-10]
+	_ = x[Debian10-11]
+	_ = x[Debian11-12]
+	_ = x[Kusanagi-13]
 }
 
-const _ArchiveOSType_name = "CustomCentOSCentOS8StreamCentOS7AlmaLinuxRockyLinuxMiracleLinuxUbuntuUbuntu2204Ubuntu2004Ubuntu1804DebianDebian10Debian11RancherOSK3OSKusanagi"
+const _ArchiveOSType_name = "CustomCentOSCentOS7AlmaLinuxRockyLinuxMiracleLinuxUbuntuUbuntu2204Ubuntu2004Ubuntu1804DebianDebian10Debian11Kusanagi"
 
-var _ArchiveOSType_index = [...]uint8{0, 6, 12, 25, 32, 41, 51, 63, 69, 79, 89, 99, 105, 113, 121, 130, 134, 142}
+var _ArchiveOSType_index = [...]uint8{0, 6, 12, 19, 28, 38, 50, 56, 66, 76, 86, 92, 100, 108, 116}
 
 func (i ArchiveOSType) String() string {
 	if i < 0 || i >= ArchiveOSType(len(_ArchiveOSType_index)-1) {

--- a/ostype/filter_criteria.go
+++ b/ostype/filter_criteria.go
@@ -26,10 +26,6 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("distro-centos"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
-	CentOS8Stream: {
-		search.Key(keys.Tags):  search.TagsAndEqual("distro-ver-8-stream", "distro-centos"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
 	CentOS7: {
 		search.Key(keys.Tags):  search.TagsAndEqual("centos-7-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
@@ -72,14 +68,6 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 	},
 	Debian11: {
 		search.Key(keys.Tags):  search.TagsAndEqual("debian-11-latest"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
-	RancherOS: {
-		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-rancheros"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
-	K3OS: {
-		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-k3os"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Kusanagi: {

--- a/ostype/filter_criteria.go
+++ b/ostype/filter_criteria.go
@@ -34,12 +34,32 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-alma"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
+	AlmaLinux9: {
+		search.Key(keys.Tags):  search.TagsAndEqual("alma-9-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
+	AlmaLinux8: {
+		search.Key(keys.Tags):  search.TagsAndEqual("alma-8-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
 	RockyLinux: {
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-rocky"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
+	RockyLinux9: {
+		search.Key(keys.Tags):  search.TagsAndEqual("rocky-9-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
+	RockyLinux8: {
+		search.Key(keys.Tags):  search.TagsAndEqual("rocky-8-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
 	MiracleLinux: {
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-miracle"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
+	MiracleLinux8: {
+		search.Key(keys.Tags):  search.TagsAndEqual("miracle-8-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Ubuntu: {


### PR DESCRIPTION
closes #111 

ostypeを最新状態に更新する(9/29以降にマージする)

#### 削除

- CentOS8Stream
- RancherOS
- K3OS

#### 追加

- AlmaLinux9
- AlmaLinux8
- RockyLinux9
- RockyLinux8
- MiracleLinux8
- 