### PR TITLE
データベースアプライアンスの/statusで特定のフィールドの値が文字列/数値混在する問題への対応

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - errcheck
     - exportloopref
@@ -28,7 +27,6 @@ linters:
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
   # don't enable:

--- a/naked/database.go
+++ b/naked/database.go
@@ -249,11 +249,11 @@ type DatabaseStatusPostgreSQL struct {
 
 // DatabaseStatusVersion データベース設定バージョン情報
 type DatabaseStatusVersion struct {
-	LastModified string `json:"lastmodified,omitempty" yaml:"last_modified,omitempty" structs:",omitempty"`
-	CommitHash   string `json:"commithash,omitempty" yaml:"commit_hash,omitempty" structs:",omitempty"`
-	Status       string `json:"status,omitempty" yaml:"status,omitempty" structs:",omitempty"`
-	Tag          string `json:"tag,omitempty" yaml:"tag,omitempty" structs:",omitempty"`
-	Expire       string `json:"expire,omitempty" yaml:"expire,omitempty" structs:",omitempty"`
+	LastModified string      `json:"lastmodified,omitempty" yaml:"last_modified,omitempty" structs:",omitempty"`
+	CommitHash   string      `json:"commithash,omitempty" yaml:"commit_hash,omitempty" structs:",omitempty"`
+	Status       string      `json:"status,omitempty" yaml:"status,omitempty" structs:",omitempty"`
+	Tag          interface{} `json:"tag,omitempty" yaml:"tag,omitempty" structs:",omitempty"` // Note: `1.1`や`"1.1"`などと表記揺れがあるためここではinterface{}で受け取る
+	Expire       string      `json:"expire,omitempty" yaml:"expire,omitempty" structs:",omitempty"`
 }
 
 // DatabaseLog データベースログ


### PR DESCRIPTION
from: https://github.com/sacloud/terraform-provider-sakuracloud/issues/988

`Tag`フィールドで文字列/数値が混在するためinterface{}で受け取るようにする。