### PR TITLE
fix: ELB.BackendHttpKeepAliveの省略対応

### DIFF
--- a/naked/proxylb.go
+++ b/naked/proxylb.go
@@ -85,18 +85,18 @@ type ProxyLBSettings struct {
 
 // ProxyLBSetting エンハンスドロードバランサ設定
 type ProxyLBSetting struct {
-	HealthCheck          ProxyLBHealthCheck          `yaml:"health_check"`                                                  // ヘルスチェック
-	SorryServer          ProxyLBSorryServer          `yaml:"sorry_server"`                                                  // ソーリーサーバー
-	BindPorts            []*ProxyLBBindPorts         `yaml:"bind_ports"`                                                    // プロキシ方式(プロトコル&ポート)
-	Servers              []ProxyLBServer             `yaml:"servers"`                                                       // サーバー
-	Rules                []ProxyLBRule               `yaml:"rules"`                                                         // 振り分けルール
-	LetsEncrypt          *ProxyLBACMESetting         `json:",omitempty" yaml:"lets_encrypt,omitempty" structs:",omitempty"` // Let's encryptでの証明書取得設定
-	StickySession        ProxyLBStickySession        `yaml:"sticky_session"`                                                // StickySession
-	Timeout              ProxyLBTimeout              `json:",omitempty" yaml:"timeout,omitempty" structs:",omitempty"`      // タイムアウト
-	Gzip                 ProxyLBGzip                 `yaml:"gzip"`                                                          // Gzip
-	BackendHttpKeepAlive ProxyLBBackendHTTPKeepAlive `yaml:"backend_http_keey_alive"`                                       // 実サーバとのHTTP持続接続
-	ProxyProtocol        ProxyLBProxyProtocol        `yaml:"proxy_protocol"`
-	Syslog               ProxyLBSyslog               `yaml:"syslog"`
+	HealthCheck          ProxyLBHealthCheck           `yaml:"health_check"`                                                              // ヘルスチェック
+	SorryServer          ProxyLBSorryServer           `yaml:"sorry_server"`                                                              // ソーリーサーバー
+	BindPorts            []*ProxyLBBindPorts          `yaml:"bind_ports"`                                                                // プロキシ方式(プロトコル&ポート)
+	Servers              []ProxyLBServer              `yaml:"servers"`                                                                   // サーバー
+	Rules                []ProxyLBRule                `yaml:"rules"`                                                                     // 振り分けルール
+	LetsEncrypt          *ProxyLBACMESetting          `json:",omitempty" yaml:"lets_encrypt,omitempty" structs:",omitempty"`             // Let's encryptでの証明書取得設定
+	StickySession        ProxyLBStickySession         `yaml:"sticky_session"`                                                            // StickySession
+	Timeout              ProxyLBTimeout               `json:",omitempty" yaml:"timeout,omitempty" structs:",omitempty"`                  // タイムアウト
+	Gzip                 ProxyLBGzip                  `yaml:"gzip"`                                                                      // Gzip
+	BackendHttpKeepAlive *ProxyLBBackendHTTPKeepAlive `json:",omitempty" yaml:",backend_http_keey_alive,omitempty" structs:",omitempty"` // 実サーバとのHTTP持続接続
+	ProxyProtocol        ProxyLBProxyProtocol         `yaml:"proxy_protocol"`
+	Syslog               ProxyLBSyslog                `yaml:"syslog"`
 }
 
 // MarshalJSON nullの場合に空配列を出力するための実装

--- a/test/proxylb_op_test.go
+++ b/test/proxylb_op_test.go
@@ -465,9 +465,6 @@ func initProxyLBVariables() {
 		Gzip: &iaas.ProxyLBGzip{
 			Enabled: false,
 		},
-		BackendHttpKeepAlive: &iaas.ProxyLBBackendHttpKeepAlive{
-			Mode: types.ProxyLBBackendHttpKeepAlive.Safe,
-		},
 		ProxyProtocol: &iaas.ProxyLBProxyProtocol{
 			Enabled: false,
 		},


### PR DESCRIPTION
BackendHttpKeepAliveはsafe or aggressiveの2値のみで空にすることはないためomitemptyを付与して対応