### PR TITLE
Enhanced DBでのMariaDB対応 & 東京リージョン対応

### DIFF
--- a/fake/ops_enhanced_db.go
+++ b/fake/ops_enhanced_db.go
@@ -16,6 +16,7 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
@@ -44,10 +45,14 @@ func (o *EnhancedDBOp) Create(ctx context.Context, param *iaas.EnhancedDBCreateR
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt)
 
-	result.DatabaseType = "tidb"
-	result.Region = "is1"
+	if result.DatabaseType == "" {
+		result.DatabaseType = "tidb"
+	}
+	if result.Region == "" {
+		result.Region = "is1"
+	}
 	result.Port = 3306
-	result.HostName = result.DatabaseName + ".tidb-is1.db.sakurausercontent.com"
+	result.HostName = fmt.Sprintf("%s.%s-%s.db.sakurausercontent.com", result.DatabaseName, result.DatabaseType, result.Region)
 	result.Availability = types.Availabilities.Available
 
 	putEnhancedDB(iaas.APIDefaultZone, result)

--- a/internal/define/enhanced_database.go
+++ b/internal/define/enhanced_database.go
@@ -133,22 +133,6 @@ var (
 				Value: `"enhanceddb"`,
 			},
 			{
-				Name: "Region",
-				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					MapConv: "Status.Region",
-				},
-				Value: `"is1"`,
-			},
-			{
-				Name: "DatabaseType",
-				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					MapConv: "Status.DatabaseType",
-				},
-				Value: `"tidb"`,
-			},
-			{
 				Name: "MaxConnections",
 				Type: meta.TypeInt,
 				Tags: &dsl.FieldTags{
@@ -166,6 +150,8 @@ var (
 
 			// settings
 			fields.EnhancedDBDatabaseName(),
+			fields.EnhancedDBDatabaseType(),
+			fields.EnhancedDBDatabaseRegion(),
 		},
 	}
 

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -1898,7 +1898,7 @@ func (f *fieldsDef) EnhancedDBDatabaseName() *dsl.FieldDesc {
 func (f *fieldsDef) EnhancedDBDatabaseType() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "DatabaseType",
-		Type: meta.TypeString,
+		Type: meta.Static(types.EnhancedDBType("")),
 		Tags: &dsl.FieldTags{
 			MapConv: "Status.DatabaseType",
 		},
@@ -1908,7 +1908,7 @@ func (f *fieldsDef) EnhancedDBDatabaseType() *dsl.FieldDesc {
 func (f *fieldsDef) EnhancedDBDatabaseRegion() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Region",
-		Type: meta.TypeString,
+		Type: meta.Static(types.EnhancedDBRegion("")),
 		Tags: &dsl.FieldTags{
 			MapConv: "Status.Region",
 		},

--- a/naked/enhanced_db.go
+++ b/naked/enhanced_db.go
@@ -44,11 +44,11 @@ type EnhancedDBConfig struct {
 
 // EnhancedDBStatus ステータス
 type EnhancedDBStatus struct {
-	DatabaseName string `json:"database_name,omitempty" yaml:"database_name,omitempty" structs:",omitempty"`
-	DatabaseType string `json:"database_type,omitempty" yaml:"database_type,omitempty" structs:",omitempty"`
-	Region       string `json:"region,omitempty" yaml:"region,omitempty" structs:",omitempty"`
-	HostName     string `json:"hostname,omitempty" yaml:"hostname,omitempty" structs:",omitempty"`
-	Port         int    `json:"port,omitempty" yaml:"port,omitempty" structs:",omitempty"`
+	DatabaseName string                 `json:"database_name,omitempty" yaml:"database_name,omitempty" structs:",omitempty"`
+	DatabaseType types.EnhancedDBType   `json:"database_type,omitempty" yaml:"database_type,omitempty" structs:",omitempty"`
+	Region       types.EnhancedDBRegion `json:"region,omitempty" yaml:"region,omitempty" structs:",omitempty"`
+	HostName     string                 `json:"hostname,omitempty" yaml:"hostname,omitempty" structs:",omitempty"`
+	Port         int                    `json:"port,omitempty" yaml:"port,omitempty" structs:",omitempty"`
 }
 
 // EnhancedDBPasswordSettings セッティング

--- a/test/enhanced_db_op_test.go
+++ b/test/enhanced_db_op_test.go
@@ -96,6 +96,8 @@ var (
 		Description:  "desc",
 		Tags:         []string{"tag1", "tag2"},
 		DatabaseName: sacloudtestutil.RandomName("", 32, sacloudtestutil.CharSetAlpha),
+		DatabaseType: types.EnhancedDBTypesMariaDB,
+		Region:       types.EnhancedDBRegionsTk1,
 	}
 	createEnhancedDBExpected = &iaas.EnhancedDB{
 		Name:         createEnhancedDBParam.Name,
@@ -103,9 +105,9 @@ var (
 		Tags:         createEnhancedDBParam.Tags,
 		Availability: types.Availabilities.Available,
 		DatabaseName: createEnhancedDBParam.DatabaseName,
-		DatabaseType: "tidb",
-		Region:       "is1",
-		HostName:     createEnhancedDBParam.DatabaseName + ".tidb-is1.db.sakurausercontent.com",
+		DatabaseType: types.EnhancedDBTypesMariaDB,
+		Region:       types.EnhancedDBRegionsTk1,
+		HostName:     createEnhancedDBParam.DatabaseName + ".mariadb-tk1.db.sakurausercontent.com",
 		Port:         3306,
 	}
 	updateEnhancedDBParam = &iaas.EnhancedDBUpdateRequest{
@@ -121,9 +123,9 @@ var (
 		Availability: types.Availabilities.Available,
 		IconID:       testIconID,
 		DatabaseName: createEnhancedDBParam.DatabaseName,
-		DatabaseType: "tidb",
-		Region:       "is1",
-		HostName:     createEnhancedDBParam.DatabaseName + ".tidb-is1.db.sakurausercontent.com",
+		DatabaseType: types.EnhancedDBTypesMariaDB,
+		Region:       types.EnhancedDBRegionsTk1,
+		HostName:     createEnhancedDBParam.DatabaseName + ".mariadb-tk1.db.sakurausercontent.com",
 		Port:         3306,
 	}
 )

--- a/types/enhanced_db_region.go
+++ b/types/enhanced_db_region.go
@@ -1,0 +1,50 @@
+// Copyright 2022-2023 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "strings"
+
+// EnhancedDBRegion エンハンスドDBでのリージョン
+type EnhancedDBRegion string
+
+// String RDBMSRegionの文字列表現
+func (t EnhancedDBRegion) String() string {
+	return string(t)
+}
+
+const (
+	// EnhancedDBRegionsTiDB TiDB
+	EnhancedDBRegionsIs1 = EnhancedDBRegion("is1")
+	// EnhancedDBRegionsMariaDB MariaDB
+	EnhancedDBRegionsTk1 = EnhancedDBRegion("tk1")
+)
+
+// EnhancedDBRegionStrings 有効なリージョンを示す文字列
+var EnhancedDBRegionStrings = []string{
+	strings.ToLower(EnhancedDBRegionsIs1.String()),
+	strings.ToLower(EnhancedDBRegionsTk1.String()),
+}
+
+// EnhancedDBRegionFromString 文字列からEnhancedDBRegionを取得
+func EnhancedDBRegionFromString(s string) EnhancedDBRegion {
+	switch {
+	case strings.ToLower(s) == strings.ToLower(EnhancedDBRegionsIs1.String()):
+		return EnhancedDBRegionsIs1
+	case strings.ToLower(s) == strings.ToLower(EnhancedDBRegionsTk1.String()):
+		return EnhancedDBRegionsTk1
+	default:
+		return EnhancedDBRegion(s)
+	}
+}

--- a/types/enhanced_db_type.go
+++ b/types/enhanced_db_type.go
@@ -1,0 +1,50 @@
+// Copyright 2022-2023 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "strings"
+
+// EnhancedDBType エンハンスドデータベースでの種別
+type EnhancedDBType string
+
+// String EnhancedDBTypeの文字列表現
+func (t EnhancedDBType) String() string {
+	return string(t)
+}
+
+const (
+	// EnhancedDBTypesTiDB TiDB
+	EnhancedDBTypesTiDB = EnhancedDBType("tidb")
+	// EnhancedDBTypesMariaDB MariaDB
+	EnhancedDBTypesMariaDB = EnhancedDBType("mariadb")
+)
+
+// EnhancedDBTypeStrings 有効な種別を示す文字列
+var EnhancedDBTypeStrings = []string{
+	strings.ToLower(EnhancedDBTypesTiDB.String()),
+	strings.ToLower(EnhancedDBTypesMariaDB.String()),
+}
+
+// EnhancedDBTypeFromString 文字列からEnhancedDBTypeを取得
+func EnhancedDBTypeFromString(s string) EnhancedDBType {
+	switch {
+	case strings.ToLower(s) == strings.ToLower(EnhancedDBTypesTiDB.String()):
+		return EnhancedDBTypesTiDB
+	case strings.ToLower(s) == strings.ToLower(EnhancedDBTypesMariaDB.String()):
+		return EnhancedDBTypesMariaDB
+	default:
+		return EnhancedDBType(s)
+	}
+}

--- a/zz_models.go
+++ b/zz_models.go
@@ -10537,12 +10537,12 @@ type EnhancedDB struct {
 	IconID       types.ID `mapconv:"Icon.ID"`
 	CreatedAt    time.Time
 	ModifiedAt   time.Time
-	SettingsHash string `json:",omitempty" mapconv:",omitempty"`
-	DatabaseName string `mapconv:"Status.DatabaseName"`
-	DatabaseType string `mapconv:"Status.DatabaseType"`
-	Region       string `mapconv:"Status.Region"`
-	HostName     string `mapconv:"Status.HostName"`
-	Port         int    `mapconv:"Status.Port"`
+	SettingsHash string                 `json:",omitempty" mapconv:",omitempty"`
+	DatabaseName string                 `mapconv:"Status.DatabaseName"`
+	DatabaseType types.EnhancedDBType   `mapconv:"Status.DatabaseType"`
+	Region       types.EnhancedDBRegion `mapconv:"Status.Region"`
+	HostName     string                 `mapconv:"Status.HostName"`
+	Port         int                    `mapconv:"Status.Port"`
 }
 
 // setDefaults implements iaas.argumentDefaulter
@@ -10556,12 +10556,12 @@ func (o *EnhancedDB) setDefaults() interface{} {
 		IconID       types.ID `mapconv:"Icon.ID"`
 		CreatedAt    time.Time
 		ModifiedAt   time.Time
-		SettingsHash string `json:",omitempty" mapconv:",omitempty"`
-		DatabaseName string `mapconv:"Status.DatabaseName"`
-		DatabaseType string `mapconv:"Status.DatabaseType"`
-		Region       string `mapconv:"Status.Region"`
-		HostName     string `mapconv:"Status.HostName"`
-		Port         int    `mapconv:"Status.Port"`
+		SettingsHash string                 `json:",omitempty" mapconv:",omitempty"`
+		DatabaseName string                 `mapconv:"Status.DatabaseName"`
+		DatabaseType types.EnhancedDBType   `mapconv:"Status.DatabaseType"`
+		Region       types.EnhancedDBRegion `mapconv:"Status.Region"`
+		HostName     string                 `mapconv:"Status.HostName"`
+		Port         int                    `mapconv:"Status.Port"`
 	}{
 		ID:           o.GetID(),
 		Name:         o.GetName(),
@@ -10721,22 +10721,22 @@ func (o *EnhancedDB) SetDatabaseName(v string) {
 }
 
 // GetDatabaseType returns value of DatabaseType
-func (o *EnhancedDB) GetDatabaseType() string {
+func (o *EnhancedDB) GetDatabaseType() types.EnhancedDBType {
 	return o.DatabaseType
 }
 
 // SetDatabaseType sets value to DatabaseType
-func (o *EnhancedDB) SetDatabaseType(v string) {
+func (o *EnhancedDB) SetDatabaseType(v types.EnhancedDBType) {
 	o.DatabaseType = v
 }
 
 // GetRegion returns value of Region
-func (o *EnhancedDB) GetRegion() string {
+func (o *EnhancedDB) GetRegion() types.EnhancedDBRegion {
 	return o.Region
 }
 
 // SetRegion sets value to Region
-func (o *EnhancedDB) SetRegion(v string) {
+func (o *EnhancedDB) SetRegion(v types.EnhancedDBRegion) {
 	o.Region = v
 }
 
@@ -10769,8 +10769,10 @@ type EnhancedDBCreateRequest struct {
 	Name         string
 	Description  string
 	Tags         types.Tags
-	IconID       types.ID `mapconv:"Icon.ID"`
-	DatabaseName string   `mapconv:"Status.DatabaseName"`
+	IconID       types.ID               `mapconv:"Icon.ID"`
+	DatabaseName string                 `mapconv:"Status.DatabaseName"`
+	DatabaseType types.EnhancedDBType   `mapconv:"Status.DatabaseType"`
+	Region       types.EnhancedDBRegion `mapconv:"Status.Region"`
 }
 
 // setDefaults implements iaas.argumentDefaulter
@@ -10779,21 +10781,21 @@ func (o *EnhancedDBCreateRequest) setDefaults() interface{} {
 		Name           string
 		Description    string
 		Tags           types.Tags
-		IconID         types.ID `mapconv:"Icon.ID"`
-		DatabaseName   string   `mapconv:"Status.DatabaseName"`
-		Class          string   `mapconv:"Provider.Class"`
-		Region         string   `mapconv:"Status.Region"`
-		DatabaseType   string   `mapconv:"Status.DatabaseType"`
-		MaxConnections int      `mapconv:"Config.MaxConnections"`
+		IconID         types.ID               `mapconv:"Icon.ID"`
+		DatabaseName   string                 `mapconv:"Status.DatabaseName"`
+		DatabaseType   types.EnhancedDBType   `mapconv:"Status.DatabaseType"`
+		Region         types.EnhancedDBRegion `mapconv:"Status.Region"`
+		Class          string                 `mapconv:"Provider.Class"`
+		MaxConnections int                    `mapconv:"Config.MaxConnections"`
 	}{
 		Name:           o.GetName(),
 		Description:    o.GetDescription(),
 		Tags:           o.GetTags(),
 		IconID:         o.GetIconID(),
 		DatabaseName:   o.GetDatabaseName(),
+		DatabaseType:   o.GetDatabaseType(),
+		Region:         o.GetRegion(),
 		Class:          "enhanceddb",
-		Region:         "is1",
-		DatabaseType:   "tidb",
 		MaxConnections: 50,
 	}
 }
@@ -10866,6 +10868,26 @@ func (o *EnhancedDBCreateRequest) GetDatabaseName() string {
 // SetDatabaseName sets value to DatabaseName
 func (o *EnhancedDBCreateRequest) SetDatabaseName(v string) {
 	o.DatabaseName = v
+}
+
+// GetDatabaseType returns value of DatabaseType
+func (o *EnhancedDBCreateRequest) GetDatabaseType() types.EnhancedDBType {
+	return o.DatabaseType
+}
+
+// SetDatabaseType sets value to DatabaseType
+func (o *EnhancedDBCreateRequest) SetDatabaseType(v types.EnhancedDBType) {
+	o.DatabaseType = v
+}
+
+// GetRegion returns value of Region
+func (o *EnhancedDBCreateRequest) GetRegion() types.EnhancedDBRegion {
+	return o.Region
+}
+
+// SetRegion sets value to Region
+func (o *EnhancedDBCreateRequest) SetRegion(v types.EnhancedDBRegion) {
+	o.Region = v
 }
 
 /*************************************************


### PR DESCRIPTION
⚠️ breaking-changeを含みます(LABプロダクト)

- MariaDBに対応
- 東京リージョンに対応
- 従来は固定だったDatabaseType/DatabaseRegionを作成時に指定可能に
- DatabaseType/DatabaseRegionをstring -> 独自型に