### PR TITLE
OSType更新

### DIFF
--- a/helper/query/archive_find_by_ostype_test.go
+++ b/helper/query/archive_find_by_ostype_test.go
@@ -41,15 +41,15 @@ func TestFindArchiveByOSType(t *testing.T) {
 			expectedError: errors.New("unsupported ostype.ArchiveOSType: Custom"),
 		},
 		{
-			input: ostype.CentOS,
+			input: ostype.Ubuntu,
 			finder: &dummyArchiveFinder{
 				archive: &iaas.ArchiveFindResult{}, // count: 0
 			},
 			expectedValue: nil,
-			expectedError: errors.New("archive not found with ostype.ArchiveOSType: CentOS"),
+			expectedError: errors.New("archive not found with ostype.ArchiveOSType: Ubuntu"),
 		},
 		{
-			input: ostype.CentOS,
+			input: ostype.Ubuntu,
 			finder: &dummyArchiveFinder{
 				archive: &iaas.ArchiveFindResult{
 					Count: 2,

--- a/ostype/archive_ostype.go
+++ b/ostype/archive_ostype.go
@@ -24,11 +24,6 @@ const (
 	// Custom OS種別:カスタム
 	Custom ArchiveOSType = iota
 
-	// CentOS OS種別:CentOS
-	CentOS
-	// CentOS7 OS種別:CentOS7
-	CentOS7
-
 	// AlmaLinux OS種別: Alma Linux
 	AlmaLinux
 	// AlmaLinux9 OS種別: Alma Linux9
@@ -52,17 +47,15 @@ const (
 
 	// Ubuntu OS種別:Ubuntu
 	Ubuntu
+	// Ubuntu2404 OS種別:Ubuntu
+	Ubuntu2404
 	// Ubuntu2204 OS種別:Ubuntu(Jammy Jellyfish)
 	Ubuntu2204
 	// Ubuntu2004 OS種別:Ubuntu(Focal Fossa)
 	Ubuntu2004
-	// Ubuntu1804 OS種別:Ubuntu(Bionic)
-	Ubuntu1804
 
 	// Debian OS種別:Debian
 	Debian
-	// Debian10 OS種別:Debian10
-	Debian10
 	// Debian11 OS種別:Debian11
 	Debian11
 
@@ -72,8 +65,6 @@ const (
 
 // ArchiveOSTypes アーカイブ種別のリスト
 var ArchiveOSTypes = []ArchiveOSType{
-	CentOS,
-	CentOS7,
 	AlmaLinux,
 	AlmaLinux9,
 	AlmaLinux8,
@@ -84,35 +75,33 @@ var ArchiveOSTypes = []ArchiveOSType{
 	MiracleLinux8,
 	MiracleLinux9,
 	Ubuntu,
+	Ubuntu2404,
 	Ubuntu2204,
 	Ubuntu2004,
-	Ubuntu1804,
 	Debian,
-	Debian10,
 	Debian11,
 	Kusanagi,
 }
 
 // OSTypeShortNames OSTypeとして利用できる文字列のリスト
 var OSTypeShortNames = []string{
-	"centos", "centos7",
 	"almalinux", "almalinux9", "almalinux8",
 	"rockylinux", "rockylinux9", "rockylinux8",
 	"miracle", "miraclelinux", "miracle8", "miraclelinux8", "miracle9", "miraclelinux9",
-	"ubuntu", "ubuntu2204", "ubuntu2004", "ubuntu1804",
-	"debian", "debian10", "debian11",
+	"ubuntu", "ubuntu2404", "ubuntu2204", "ubuntu2004",
+	"debian", "debian11",
 	"kusanagi",
 }
 
 // IsSupportDiskEdit ディスクの修正機能をフルサポートしているか(Windowsは一部サポートのためfalseを返す)
 func (o ArchiveOSType) IsSupportDiskEdit() bool {
 	switch o {
-	case CentOS, CentOS7,
+	case
 		AlmaLinux, AlmaLinux9, AlmaLinux8,
 		RockyLinux, RockyLinux9, RockyLinux8,
 		MiracleLinux, MiracleLinux8, MiracleLinux9,
-		Ubuntu, Ubuntu2204, Ubuntu2004, Ubuntu1804,
-		Debian, Debian10, Debian11,
+		Ubuntu, Ubuntu2404, Ubuntu2204, Ubuntu2004,
+		Debian, Debian11,
 		Kusanagi:
 		return true
 	default:
@@ -123,10 +112,6 @@ func (o ArchiveOSType) IsSupportDiskEdit() bool {
 // StrToOSType 文字列からArchiveOSTypesへの変換
 func StrToOSType(osType string) ArchiveOSType {
 	switch osType {
-	case "centos":
-		return CentOS
-	case "centos7":
-		return CentOS7
 	case "almalinux":
 		return AlmaLinux
 	case "almalinux9":
@@ -147,16 +132,14 @@ func StrToOSType(osType string) ArchiveOSType {
 		return MiracleLinux9
 	case "ubuntu":
 		return Ubuntu
+	case "ubuntu2404":
+		return Ubuntu2404
 	case "ubuntu2204":
 		return Ubuntu2204
 	case "ubuntu2004":
 		return Ubuntu2004
-	case "ubuntu1804":
-		return Ubuntu1804
 	case "debian":
 		return Debian
-	case "debian10":
-		return Debian10
 	case "debian11":
 		return Debian11
 	case "kusanagi":

--- a/ostype/archiveostype_string.go
+++ b/ostype/archiveostype_string.go
@@ -23,30 +23,27 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[Custom-0]
-	_ = x[CentOS-1]
-	_ = x[CentOS7-2]
-	_ = x[AlmaLinux-3]
-	_ = x[AlmaLinux9-4]
-	_ = x[AlmaLinux8-5]
-	_ = x[RockyLinux-6]
-	_ = x[RockyLinux9-7]
-	_ = x[RockyLinux8-8]
-	_ = x[MiracleLinux-9]
-	_ = x[MiracleLinux8-10]
-	_ = x[MiracleLinux9-11]
-	_ = x[Ubuntu-12]
-	_ = x[Ubuntu2204-13]
-	_ = x[Ubuntu2004-14]
-	_ = x[Ubuntu1804-15]
-	_ = x[Debian-16]
-	_ = x[Debian10-17]
-	_ = x[Debian11-18]
-	_ = x[Kusanagi-19]
+	_ = x[AlmaLinux-1]
+	_ = x[AlmaLinux9-2]
+	_ = x[AlmaLinux8-3]
+	_ = x[RockyLinux-4]
+	_ = x[RockyLinux9-5]
+	_ = x[RockyLinux8-6]
+	_ = x[MiracleLinux-7]
+	_ = x[MiracleLinux8-8]
+	_ = x[MiracleLinux9-9]
+	_ = x[Ubuntu-10]
+	_ = x[Ubuntu2404-11]
+	_ = x[Ubuntu2204-12]
+	_ = x[Ubuntu2004-13]
+	_ = x[Debian-14]
+	_ = x[Debian11-15]
+	_ = x[Kusanagi-16]
 }
 
-const _ArchiveOSType_name = "CustomCentOSCentOS7AlmaLinuxAlmaLinux9AlmaLinux8RockyLinuxRockyLinux9RockyLinux8MiracleLinuxMiracleLinux8MiracleLinux9UbuntuUbuntu2204Ubuntu2004Ubuntu1804DebianDebian10Debian11Kusanagi"
+const _ArchiveOSType_name = "CustomAlmaLinuxAlmaLinux9AlmaLinux8RockyLinuxRockyLinux9RockyLinux8MiracleLinuxMiracleLinux8MiracleLinux9UbuntuUbuntu2404Ubuntu2204Ubuntu2004DebianDebian11Kusanagi"
 
-var _ArchiveOSType_index = [...]uint8{0, 6, 12, 19, 28, 38, 48, 58, 69, 80, 92, 105, 118, 124, 134, 144, 154, 160, 168, 176, 184}
+var _ArchiveOSType_index = [...]uint8{0, 6, 15, 25, 35, 45, 56, 67, 79, 92, 105, 111, 121, 131, 141, 147, 155, 163}
 
 func (i ArchiveOSType) String() string {
 	if i < 0 || i >= ArchiveOSType(len(_ArchiveOSType_index)-1) {

--- a/ostype/filter_criteria.go
+++ b/ostype/filter_criteria.go
@@ -22,14 +22,6 @@ import (
 
 // ArchiveCriteria OSTypeごとのアーカイブ検索条件
 var ArchiveCriteria = map[ArchiveOSType]search.Filter{
-	CentOS: {
-		search.Key(keys.Tags):  search.TagsAndEqual("distro-centos"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
-	CentOS7: {
-		search.Key(keys.Tags):  search.TagsAndEqual("centos-7-latest"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
 	AlmaLinux: {
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-alma"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
@@ -70,6 +62,10 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-ubuntu"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
+	Ubuntu2404: {
+		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-24.04-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
 	Ubuntu2204: {
 		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-22.04-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
@@ -78,16 +74,8 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-20.04-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
-	Ubuntu1804: {
-		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-18.04-latest"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
 	Debian: {
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-debian"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
-	Debian10: {
-		search.Key(keys.Tags):  search.TagsAndEqual("debian-10-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Debian11: {


### PR DESCRIPTION
- CentOSとCentOS7, Debian10を除去
- Ubuntu 2404を追加

Note: Debian12はcloudimg版のみしか提供されていないためostypeではサポートしない