### PR TITLE
goreleaser v2に対応

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,12 +20,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
-build:
-  skip: true
+version: 2
+builds:
+  - skip: true
 release:
   draft: false
 changelog:
-  skip: false
+  disable: false


### PR DESCRIPTION
## 背景
https://github.com/sacloud/iaas-api-go/pull/317 によりgoreleaser v2が使われるようになったため関連する設定項目を修正する

https://github.com/sacloud/webaccel-api-go/pull/56 を参考にしています。

## 変更点
- goreleaserのconfigをv2に対応
- GitHub ActionsでGoのバージョン判定にgo.modを利用するように変更