### PR TITLE
docomo回線提供終了対応

### DIFF
--- a/types/sim_network_operators.go
+++ b/types/sim_network_operators.go
@@ -25,18 +25,15 @@ func (o ESIMOperatorName) String() string {
 // SIMOperators SIMキャリア名
 var SIMOperators = struct {
 	KDDI     ESIMOperatorName
-	Docomo   ESIMOperatorName
 	SoftBank ESIMOperatorName
 }{
 	KDDI:     ESIMOperatorName("KDDI"),
-	Docomo:   ESIMOperatorName("NTT DOCOMO"),
 	SoftBank: ESIMOperatorName("SoftBank"),
 }
 
 // SIMOperatorShortNameMap 省略名をキーとするESIMOperatorNameのマップ
 var SIMOperatorShortNameMap = map[string]ESIMOperatorName{
 	"kddi":     SIMOperators.KDDI,
-	"docomo":   SIMOperators.Docomo,
 	"softbank": SIMOperators.SoftBank,
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

セキュアモバイルでのdocomo回線廃止に対応する
https://www.sakura.ad.jp/corporate/information/announcements/2025/03/14/1968218982/

なお、このPR時点では価格表APIなどにDocomo表記が残っている部分があるために一部 `docomo`記述が残っている。

### ドキュメントの変更は必要ですか？

no