### PR TITLE
Handle optional BinlogUsedSizeKiB and DelayTimeSec in DB monitor

### DIFF
--- a/naked/monitor.go
+++ b/naked/monitor.go
@@ -669,25 +669,29 @@ func (m *rawMonitorValues) monitorDatabaseValues() (MonitorDatabaseValues, error
 	for k, v := range *m {
 		if v.TotalMemorySize == nil || v.UsedMemorySize == nil ||
 			v.TotalDisk1Size == nil || v.UsedDisk1Size == nil ||
-			v.TotalDisk2Size == nil || v.UsedDisk2Size == nil ||
-			v.BinlogUsedSizeKiB == nil || v.DelayTimeSec == nil {
+			v.TotalDisk2Size == nil || v.UsedDisk2Size == nil {
 			continue
 		}
 		time, err := time.Parse(time.RFC3339, k) // RFC3339 ≒ ISO8601
 		if err != nil {
 			return nil, err
 		}
-		values = append(values, &MonitorDatabaseValue{
-			Time:              time,
-			TotalMemorySize:   *v.TotalMemorySize,
-			UsedMemorySize:    *v.UsedMemorySize,
-			TotalDisk1Size:    *v.TotalDisk1Size,
-			UsedDisk1Size:     *v.UsedDisk1Size,
-			TotalDisk2Size:    *v.TotalDisk2Size,
-			UsedDisk2Size:     *v.UsedDisk2Size,
-			BinlogUsedSizeKiB: *v.BinlogUsedSizeKiB,
-			DelayTimeSec:      *v.DelayTimeSec,
-		})
+		value := &MonitorDatabaseValue{
+			Time:            time,
+			TotalMemorySize: *v.TotalMemorySize,
+			UsedMemorySize:  *v.UsedMemorySize,
+			TotalDisk1Size:  *v.TotalDisk1Size,
+			UsedDisk1Size:   *v.UsedDisk1Size,
+			TotalDisk2Size:  *v.TotalDisk2Size,
+			UsedDisk2Size:   *v.UsedDisk2Size,
+		}
+		if v.BinlogUsedSizeKiB != nil {
+			value.BinlogUsedSizeKiB = *v.BinlogUsedSizeKiB
+		}
+		if v.DelayTimeSec != nil {
+			value.DelayTimeSec = *v.DelayTimeSec
+		}
+		values = append(values, value)
 	}
 
 	sort.Slice(values, func(i, j int) bool { return values[i].Time.Before(values[j].Time) })

--- a/naked/monitor_test.go
+++ b/naked/monitor_test.go
@@ -140,6 +140,14 @@ const (
             "Used-Disk2-Size"    : 62.0,
             "binlogUsedSizeKiB": 72.0,
             "delayTimeSec"     : 82.0
+        },
+        "1970-01-01T00:00:05Z": {
+            "Total-Memory-Size"  : 13.0, 
+            "Used-Memory-Size"   : 23.0,
+            "Total-Disk1-Size"   : 33.0,
+            "Used-Disk1-Size"    : 43.0,
+            "Total-Disk2-Size"   : 53.0,
+            "Used-Disk2-Size"    : 63.0
         }
     }`
 
@@ -362,6 +370,17 @@ func TestMonitorValues_UnmarshalJSON(t *testing.T) {
 						UsedDisk2Size:     float64(62.0),
 						BinlogUsedSizeKiB: float64(72.0),
 						DelayTimeSec:      float64(82.0),
+					},
+					{
+						Time:              time.Unix(5, 0).UTC(),
+						TotalMemorySize:   float64(13.0),
+						UsedMemorySize:    float64(23.0),
+						TotalDisk1Size:    float64(33.0),
+						UsedDisk1Size:     float64(43.0),
+						TotalDisk2Size:    float64(53.0),
+						UsedDisk2Size:     float64(63.0),
+						BinlogUsedSizeKiB: float64(0.0),
+						DelayTimeSec:      float64(0.0),
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

データベースアプライアンスのアクティビティについて、作成時に特定の構成(非冗長化プラン、かつレプリケーションが無効)の場合に正常に取得できない問題を修正した。

### ドキュメントの変更は必要ですか？

no