### PR TITLE
Always include password field in ContainerRegistryUser

### DIFF
--- a/naked/container_registry.go
+++ b/naked/container_registry.go
@@ -63,7 +63,7 @@ type ContainerRegistryStatus struct {
 // ContainerRegistryUser コンテナレジストリのユーザ
 type ContainerRegistryUser struct {
 	UserName   string                             `json:"username,omitempty" yaml:"username,omitempty"`
-	Password   string                             `json:"password,omitempty" yaml:"password,omitempty"`
+	Password   string                             `json:"password" yaml:"password"`
 	Permission types.EContainerRegistryPermission `json:"permission" yaml:"permission"`
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

コンテナレジストリでユーザーの情報を更新する際、passwordフィールドをnullにするとエラーになる問題を修正。
omitemptyを除去し常にフィールドをリクエストに含めるようにした。

### ドキュメントの変更は必要ですか？

no