### PR TITLE
fix: add almalinux8 and rockylinux8 back to ostype

### DIFF
--- a/helper/query/archive_find_by_ostype_test.go
+++ b/helper/query/archive_find_by_ostype_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/ostype"
 	"github.com/sacloud/iaas-api-go/testutil"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,7 +97,7 @@ func TestAccFindArchiveByOSType(t *testing.T) {
 	archiveOp := iaas.NewArchiveOp(caller)
 	ctx := context.Background()
 
-	zones := []string{"is1a", "is1b", "tk1a", "tk1b", "tk1v"} // TODO is1cリリース後にtypes.ZoneNamesを使うように切り替える
+	zones := types.ZoneNames
 
 	for _, zone := range zones {
 		for _, os := range ostype.ArchiveOSTypes {

--- a/ostype/archive_ostype.go
+++ b/ostype/archive_ostype.go
@@ -30,6 +30,8 @@ const (
 	AlmaLinux10
 	// AlmaLinux9 OS種別: Alma Linux9
 	AlmaLinux9
+	// AlmaLinux8 OS種別: Alma Linux8
+	AlmaLinux8
 
 	// RockyLinux OS種別: Rocky Linux
 	RockyLinux
@@ -37,13 +39,15 @@ const (
 	RockyLinux10
 	// RockyLinux9 OS種別: Rocky Linux9
 	RockyLinux9
+	// RockyLinux8 OS種別: Rocky Linux8
+	RockyLinux8
 
 	// MiracleLinux OS種別: MIRACLE LINUX
 	MiracleLinux
-	// MiracleLinux8 OS種別: MIRACLE LINUX8
-	MiracleLinux8
 	// MiracleLinux9 OS種別: MIRACLE LINUX9
 	MiracleLinux9
+	// MiracleLinux8 OS種別: MIRACLE LINUX8
+	MiracleLinux8
 
 	// Ubuntu OS種別:Ubuntu
 	Ubuntu
@@ -54,10 +58,10 @@ const (
 
 	// Debian OS種別:Debian
 	Debian
-	// Debian11 OS種別:Debian11
-	Debian11
 	// Debian12 OS種別:Debian12
 	Debian12
+	// Debian11 OS種別:Debian11
+	Debian11
 
 	// Kusanagi OS種別:Kusanagi(CentOS)
 	Kusanagi
@@ -68,28 +72,30 @@ var ArchiveOSTypes = []ArchiveOSType{
 	AlmaLinux,
 	AlmaLinux10,
 	AlmaLinux9,
+	AlmaLinux8,
 	RockyLinux,
 	RockyLinux10,
 	RockyLinux9,
+	RockyLinux8,
 	MiracleLinux,
-	MiracleLinux8,
 	MiracleLinux9,
+	MiracleLinux8,
 	Ubuntu,
 	Ubuntu2404,
 	Ubuntu2204,
 	Debian,
-	Debian11,
 	Debian12,
+	Debian11,
 	Kusanagi,
 }
 
 // OSTypeShortNames OSTypeとして利用できる文字列のリスト
 var OSTypeShortNames = []string{
-	"almalinux", "almalinux10", "almalinux9",
-	"rockylinux", "rockylinux10", "rockylinux9",
-	"miracle", "miraclelinux", "miracle8", "miraclelinux8", "miracle9", "miraclelinux9",
+	"almalinux", "almalinux10", "almalinux9", "almalinux8",
+	"rockylinux", "rockylinux10", "rockylinux9", "rockylinux8",
+	"miracle", "miraclelinux", "miracle9", "miraclelinux9", "miracle8", "miraclelinux8",
 	"ubuntu", "ubuntu2404", "ubuntu2204",
-	"debian", "debian11", "debian12",
+	"debian", "debian12", "debian11",
 	"kusanagi",
 }
 
@@ -97,11 +103,11 @@ var OSTypeShortNames = []string{
 func (o ArchiveOSType) IsSupportDiskEdit() bool {
 	switch o {
 	case
-		AlmaLinux, AlmaLinux10, AlmaLinux9,
-		RockyLinux, RockyLinux10, RockyLinux9,
-		MiracleLinux, MiracleLinux8, MiracleLinux9,
+		AlmaLinux, AlmaLinux10, AlmaLinux9, AlmaLinux8,
+		RockyLinux, RockyLinux10, RockyLinux9, RockyLinux8,
+		MiracleLinux, MiracleLinux9, MiracleLinux8,
 		Ubuntu, Ubuntu2404, Ubuntu2204,
-		Debian, Debian11, Debian12,
+		Debian, Debian12, Debian11,
 		Kusanagi:
 		return true
 	default:
@@ -118,18 +124,22 @@ func StrToOSType(osType string) ArchiveOSType {
 		return AlmaLinux10
 	case "almalinux9":
 		return AlmaLinux9
+	case "almalinux8":
+		return AlmaLinux8
 	case "rockylinux":
 		return RockyLinux
 	case "rockylinux10":
 		return RockyLinux10
 	case "rockylinux9":
 		return RockyLinux9
+	case "rockylinux8":
+		return RockyLinux8
 	case "miracle", "miraclelinux":
 		return MiracleLinux
-	case "miracle8", "miraclelinux8":
-		return MiracleLinux8
 	case "miracle9", "miraclelinux9":
 		return MiracleLinux9
+	case "miracle8", "miraclelinux8":
+		return MiracleLinux8
 	case "ubuntu":
 		return Ubuntu
 	case "ubuntu2404":
@@ -138,10 +148,10 @@ func StrToOSType(osType string) ArchiveOSType {
 		return Ubuntu2204
 	case "debian":
 		return Debian
-	case "debian11":
-		return Debian11
 	case "debian12":
 		return Debian12
+	case "debian11":
+		return Debian11
 	case "kusanagi":
 		return Kusanagi
 	default:

--- a/ostype/archiveostype_string.go
+++ b/ostype/archiveostype_string.go
@@ -26,24 +26,26 @@ func _() {
 	_ = x[AlmaLinux-1]
 	_ = x[AlmaLinux10-2]
 	_ = x[AlmaLinux9-3]
-	_ = x[RockyLinux-4]
-	_ = x[RockyLinux10-5]
-	_ = x[RockyLinux9-6]
-	_ = x[MiracleLinux-7]
-	_ = x[MiracleLinux8-8]
-	_ = x[MiracleLinux9-9]
-	_ = x[Ubuntu-10]
-	_ = x[Ubuntu2404-11]
-	_ = x[Ubuntu2204-12]
-	_ = x[Debian-13]
-	_ = x[Debian11-14]
-	_ = x[Debian12-15]
-	_ = x[Kusanagi-16]
+	_ = x[AlmaLinux8-4]
+	_ = x[RockyLinux-5]
+	_ = x[RockyLinux10-6]
+	_ = x[RockyLinux9-7]
+	_ = x[RockyLinux8-8]
+	_ = x[MiracleLinux-9]
+	_ = x[MiracleLinux9-10]
+	_ = x[MiracleLinux8-11]
+	_ = x[Ubuntu-12]
+	_ = x[Ubuntu2404-13]
+	_ = x[Ubuntu2204-14]
+	_ = x[Debian-15]
+	_ = x[Debian12-16]
+	_ = x[Debian11-17]
+	_ = x[Kusanagi-18]
 }
 
-const _ArchiveOSType_name = "CustomAlmaLinuxAlmaLinux10AlmaLinux9RockyLinuxRockyLinux10RockyLinux9MiracleLinuxMiracleLinux8MiracleLinux9UbuntuUbuntu2404Ubuntu2204DebianDebian11Debian12Kusanagi"
+const _ArchiveOSType_name = "CustomAlmaLinuxAlmaLinux10AlmaLinux9AlmaLinux8RockyLinuxRockyLinux10RockyLinux9RockyLinux8MiracleLinuxMiracleLinux9MiracleLinux8UbuntuUbuntu2404Ubuntu2204DebianDebian12Debian11Kusanagi"
 
-var _ArchiveOSType_index = [...]uint8{0, 6, 15, 26, 36, 46, 58, 69, 81, 94, 107, 113, 123, 133, 139, 147, 155, 163}
+var _ArchiveOSType_index = [...]uint8{0, 6, 15, 26, 36, 46, 56, 68, 79, 90, 102, 115, 128, 134, 144, 154, 160, 168, 176, 184}
 
 func (i ArchiveOSType) String() string {
 	idx := int(i) - 0

--- a/ostype/filter_criteria.go
+++ b/ostype/filter_criteria.go
@@ -34,6 +34,10 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("alma-9-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
+	AlmaLinux8: {
+		search.Key(keys.Tags):  search.TagsAndEqual("alma-8-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
 	RockyLinux: {
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-rocky"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
@@ -46,16 +50,20 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("rocky-9-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
+	RockyLinux8: {
+		search.Key(keys.Tags):  search.TagsAndEqual("rocky-8-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
 	MiracleLinux: {
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-miracle"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
-	MiracleLinux8: {
-		search.Key(keys.Tags):  search.TagsAndEqual("miracle-8-latest"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
 	MiracleLinux9: {
 		search.Key(keys.Tags):  search.TagsAndEqual("miracle-9-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
+	MiracleLinux8: {
+		search.Key(keys.Tags):  search.TagsAndEqual("miracle-8-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Ubuntu: {
@@ -74,12 +82,12 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-debian"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
-	Debian11: {
-		search.Key(keys.Tags):  search.TagsAndEqual("debian-11-latest"),
-		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
-	},
 	Debian12: {
 		search.Key(keys.Tags):  search.TagsAndEqual("debian-12-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
+	Debian11: {
+		search.Key(keys.Tags):  search.TagsAndEqual("debian-11-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
 	Kusanagi: {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

#405 でのostypeの修正に誤りがあり、rockylinux8とalmalinux8を消してしまっていたため修正

### ドキュメントの変更は必要ですか？

no
