### PR TITLE
Remove ReadWrite in ContainerRegistry public setting

### DIFF
--- a/test/container_registry_op_test.go
+++ b/test/container_registry_op_test.go
@@ -128,7 +128,7 @@ var (
 		Description:    "desc",
 		Tags:           []string{"tag1", "tag2"},
 		VirtualDomain:  "libsacloud-test.usacloud.jp",
-		AccessLevel:    types.ContainerRegistryAccessLevels.ReadWrite,
+		AccessLevel:    types.ContainerRegistryAccessLevels.None,
 		SubDomainLabel: sacloudtestutil.RandomName(testutil.TestResourcePrefix, 45, sacloudtestutil.CharSetAlpha),
 	}
 	createContainerRegistryExpected = &iaas.ContainerRegistry{

--- a/types/container_registry_access_level.go
+++ b/types/container_registry_access_level.go
@@ -24,25 +24,21 @@ func (v EContainerRegistryAccessLevel) String() string {
 
 // ContainerRegistryAccessLevels コンテナレジストリのアクセス範囲
 var ContainerRegistryAccessLevels = struct {
-	ReadWrite EContainerRegistryAccessLevel
 	ReadOnly  EContainerRegistryAccessLevel
 	None      EContainerRegistryAccessLevel
 }{
-	ReadWrite: "readwrite",
 	ReadOnly:  "readonly",
 	None:      "none",
 }
 
 // ContainerRegistryAccessLevelStrings アクセス範囲に指定可能な文字列
 var ContainerRegistryAccessLevelStrings = []string{
-	ContainerRegistryAccessLevels.ReadWrite.String(),
 	ContainerRegistryAccessLevels.ReadOnly.String(),
 	ContainerRegistryAccessLevels.None.String(),
 }
 
 // ContainerRegistryAccessLevelMap 文字列とEContainerRegistryVisibilityのマップ
 var ContainerRegistryAccessLevelMap = map[string]EContainerRegistryAccessLevel{
-	ContainerRegistryAccessLevels.ReadWrite.String(): ContainerRegistryAccessLevels.ReadWrite,
 	ContainerRegistryAccessLevels.ReadOnly.String():  ContainerRegistryAccessLevels.ReadOnly,
 	ContainerRegistryAccessLevels.None.String():      ContainerRegistryAccessLevels.None,
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

以下クラウドニュースにある通り、コンテナレジストリの公開設定から「Push & Pull」は廃止されたので、iaas-api-goからも削除します。

https://cloud.sakura.ad.jp/news/2026/01/22/containerregistry-privacysettings/

### ドキュメントの変更は必要ですか？
