### PR TITLE
refactor: remove text/template dependency from buildURL

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -15,14 +15,20 @@
 package iaas
 
 import (
-	"bytes"
-	"text/template"
+	"fmt"
+	"strings"
 )
 
-func buildURL(pathFormat string, param interface{}) (string, error) {
-	buf := bytes.NewBufferString("")
-	t := template.New("buildURL")
-	template.Must(t.Parse(pathFormat))
-	err := t.Execute(buf, param)
-	return buf.String(), err
+func buildURL(pathFormat string, param map[string]interface{}) (string, error) {
+	var replPairs []string
+	for k, v := range param {
+		replPairs = append(replPairs, fmt.Sprintf("{{.%s}}", k), fmt.Sprint(v))
+	}
+	replacer := strings.NewReplacer(replPairs...)
+	result := replacer.Replace(pathFormat)
+
+	if strings.Contains(result, "{{") {
+		return "", fmt.Errorf("undefined variable in URL template: %s", result)
+	}
+	return result, nil
 }

--- a/functions_test.go
+++ b/functions_test.go
@@ -1,0 +1,109 @@
+// Copyright 2022-2025 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iaas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		param   map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic substitution with multiple keys",
+			tmpl: "{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}",
+			param: map[string]interface{}{
+				"rootURL":    "https://api.example.com",
+				"zone":       "is1a",
+				"pathSuffix": "api/cloud/1.1",
+				"pathName":   "server",
+			},
+			want:    "https://api.example.com/is1a/api/cloud/1.1/server",
+			wantErr: false,
+		},
+		{
+			name: "substitution with ID",
+			tmpl: "{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}",
+			param: map[string]interface{}{
+				"rootURL":    "https://api.example.com",
+				"zone":       "is1b",
+				"pathSuffix": "api/cloud/1.1",
+				"pathName":   "archive",
+				"id":         12345,
+			},
+			want:    "https://api.example.com/is1b/api/cloud/1.1/archive/12345",
+			wantErr: false,
+		},
+		{
+			name: "numeric values are stringified",
+			tmpl: "{{.rootURL}}/{{.accountID}}/{{.year}}/{{.month}}",
+			param: map[string]interface{}{
+				"rootURL":   "https://api.example.com",
+				"accountID": 111111111111,
+				"year":      2024,
+				"month":     12,
+			},
+			want:    "https://api.example.com/111111111111/2024/12",
+			wantErr: false,
+		},
+		{
+			name: "empty template",
+			tmpl: "",
+			param: map[string]interface{}{
+				"rootURL": "https://api.example.com",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "undefined variable in template",
+			tmpl: "{{.rootURL}}/{{.zone}}/{{.undefinedKey}}",
+			param: map[string]interface{}{
+				"rootURL": "https://api.example.com",
+				"zone":    "is1a",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "same placeholder appears multiple times",
+			tmpl: "{{.zone}}/{{.zone}}/{{.zone}}",
+			param: map[string]interface{}{
+				"zone": "is1a",
+			},
+			want:    "is1a/is1a/is1a",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildURL(tt.tmpl, tt.param)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

fixes #466 

### このPRはどういう変更を行いますか？

`functions.go` の `buildURL` から `text/template` への依存を除去し、同じ機能を `strings.NewReplacer` で実現するように変更しました。
単純なプレースホルダ置換のみを行うため、テンプレートエンジンは不要です。

併せて `buildURL` の単体テストを新規追加しました。

なお、https://github.com/sacloud/iaas-api-go/blob/d09fd50ecf351b37efabcedf00914f3a6ca0d254/internal/tools/functions.go にも text/template を使っていますが、これはコード生成時のみ使われるため対応不要のはず

#466 でのデモどおりビルド後のバイナリサイズが小さくなることも確認しました

### ドキュメントの変更は必要ですか？

不要