### PR TITLE
add: OriginGuard and StrictRule fields to ProxyLB

### DIFF
--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -1830,6 +1830,42 @@ func (f *fieldsDef) ProxyLBSyslog() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) ProxyLBOriginGuard() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "OriginGuard",
+		Type: &dsl.Model{
+			Name: "ProxyLBOriginGuard",
+			Fields: []*dsl.FieldDesc{
+				{
+					Name: "Token",
+					Type: meta.TypeString,
+				},
+			},
+		},
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.ProxyLB.OriginGuard,recursive",
+		},
+	}
+}
+
+func (f *fieldsDef) ProxyLBStrictRule() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "StrictRule",
+		Type: &dsl.Model{
+			Name: "ProxyLBStrictRule",
+			Fields: []*dsl.FieldDesc{
+				{
+					Name: "Enabled",
+					Type: meta.TypeFlag,
+				},
+			},
+		},
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.ProxyLB.StrictRule,recursive",
+		},
+	}
+}
+
 func (f *fieldsDef) ProxyLBTimeout() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Timeout",

--- a/internal/define/proxylb.go
+++ b/internal/define/proxylb.go
@@ -188,6 +188,8 @@ var (
 			fields.ProxyLBMonitoringSuiteLog(),
 			fields.ProxyLBProxyProtocol(),
 			fields.ProxyLBSyslog(),
+			fields.ProxyLBOriginGuard(),
+			fields.ProxyLBStrictRule(),
 			fields.ProxyLBTimeout(),
 			fields.SettingsHash(),
 
@@ -231,6 +233,8 @@ var (
 			fields.ProxyLBMonitoringSuiteLog(),
 			fields.ProxyLBProxyProtocol(),
 			fields.ProxyLBSyslog(),
+			fields.ProxyLBOriginGuard(),
+			fields.ProxyLBStrictRule(),
 			// status
 			fields.ProxyLBUseVIPFailover(),
 			fields.ProxyLBRegion(),
@@ -262,6 +266,8 @@ var (
 			fields.ProxyLBMonitoringSuiteLog(),
 			fields.ProxyLBProxyProtocol(),
 			fields.ProxyLBSyslog(),
+			fields.ProxyLBOriginGuard(),
+			fields.ProxyLBStrictRule(),
 			// settings hash
 			fields.SettingsHash(),
 
@@ -291,6 +297,8 @@ var (
 			fields.ProxyLBMonitoringSuiteLog(),
 			fields.ProxyLBProxyProtocol(),
 			fields.ProxyLBSyslog(),
+			fields.ProxyLBOriginGuard(),
+			fields.ProxyLBStrictRule(),
 			// settings hash
 			fields.SettingsHash(),
 		},

--- a/naked/proxylb.go
+++ b/naked/proxylb.go
@@ -98,6 +98,8 @@ type ProxyLBSetting struct {
 	MonitoringSuiteLog   *MonitoringSuiteLog          `json:",omitempty" yaml:"monitoring_suite_log,omitempty" structs:",omitempty"`
 	ProxyProtocol        ProxyLBProxyProtocol         `yaml:"proxy_protocol"`
 	Syslog               ProxyLBSyslog                `yaml:"syslog"`
+	OriginGuard          *ProxyLBOriginGuard          `json:",omitempty" yaml:"origin_guard,omitempty" structs:",omitempty"`
+	StrictRule           *ProxyLBStrictRule           `json:",omitempty" yaml:"strict_rule,omitempty" structs:",omitempty"`
 }
 
 // MarshalJSON nullの場合に空配列を出力するための実装
@@ -336,6 +338,16 @@ func (p *ProxyLBCertificate) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// ProxyLBOriginGuard OriginGuard設定
+type ProxyLBOriginGuard struct {
+	Token string `yaml:"token"`
+}
+
+// ProxyLBStrictRule StrictRule設定
+type ProxyLBStrictRule struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // ProxyLBHealth ProxyLBのヘルスチェック戻り値

--- a/zz_models.go
+++ b/zz_models.go
@@ -21060,6 +21060,8 @@ type ProxyLB struct {
 	MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 	ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 	Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+	OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+	StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 	Timeout              *ProxyLBTimeout              `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 	SettingsHash         string                       `json:",omitempty" mapconv:",omitempty"`
 	UseVIPFailover       bool                         `mapconv:"Status.UseVIPFailover"`
@@ -21093,6 +21095,8 @@ func (o *ProxyLB) setDefaults() interface{} {
 		MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 		ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 		Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+		OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+		StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 		Timeout              *ProxyLBTimeout              `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 		SettingsHash         string                       `json:",omitempty" mapconv:",omitempty"`
 		UseVIPFailover       bool                         `mapconv:"Status.UseVIPFailover"`
@@ -21122,6 +21126,8 @@ func (o *ProxyLB) setDefaults() interface{} {
 		MonitoringSuiteLog:   o.GetMonitoringSuiteLog(),
 		ProxyProtocol:        o.GetProxyProtocol(),
 		Syslog:               o.GetSyslog(),
+		OriginGuard:          o.GetOriginGuard(),
+		StrictRule:           o.GetStrictRule(),
 		Timeout:              o.GetTimeout(),
 		SettingsHash:         o.GetSettingsHash(),
 		UseVIPFailover:       o.GetUseVIPFailover(),
@@ -21380,6 +21386,26 @@ func (o *ProxyLB) GetSyslog() *ProxyLBSyslog {
 // SetSyslog sets value to Syslog
 func (o *ProxyLB) SetSyslog(v *ProxyLBSyslog) {
 	o.Syslog = v
+}
+
+// GetOriginGuard returns value of OriginGuard
+func (o *ProxyLB) GetOriginGuard() *ProxyLBOriginGuard {
+	return o.OriginGuard
+}
+
+// SetOriginGuard sets value to OriginGuard
+func (o *ProxyLB) SetOriginGuard(v *ProxyLBOriginGuard) {
+	o.OriginGuard = v
+}
+
+// GetStrictRule returns value of StrictRule
+func (o *ProxyLB) GetStrictRule() *ProxyLBStrictRule {
+	return o.StrictRule
+}
+
+// SetStrictRule sets value to StrictRule
+func (o *ProxyLB) SetStrictRule(v *ProxyLBStrictRule) {
+	o.StrictRule = v
 }
 
 // GetTimeout returns value of Timeout
@@ -22195,6 +22221,62 @@ func (o *ProxyLBSyslog) SetPort(v int) {
 }
 
 /*************************************************
+* ProxyLBOriginGuard
+*************************************************/
+
+// ProxyLBOriginGuard represents API parameter/response structure
+type ProxyLBOriginGuard struct {
+	Token string
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *ProxyLBOriginGuard) setDefaults() interface{} {
+	return &struct {
+		Token string
+	}{
+		Token: o.GetToken(),
+	}
+}
+
+// GetToken returns value of Token
+func (o *ProxyLBOriginGuard) GetToken() string {
+	return o.Token
+}
+
+// SetToken sets value to Token
+func (o *ProxyLBOriginGuard) SetToken(v string) {
+	o.Token = v
+}
+
+/*************************************************
+* ProxyLBStrictRule
+*************************************************/
+
+// ProxyLBStrictRule represents API parameter/response structure
+type ProxyLBStrictRule struct {
+	Enabled bool
+}
+
+// setDefaults implements iaas.argumentDefaulter
+func (o *ProxyLBStrictRule) setDefaults() interface{} {
+	return &struct {
+		Enabled bool
+	}{
+		Enabled: o.GetEnabled(),
+	}
+}
+
+// GetEnabled returns value of Enabled
+func (o *ProxyLBStrictRule) GetEnabled() bool {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *ProxyLBStrictRule) SetEnabled(v bool) {
+	o.Enabled = v
+}
+
+/*************************************************
 * ProxyLBTimeout
 *************************************************/
 
@@ -22245,6 +22327,8 @@ type ProxyLBCreateRequest struct {
 	MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 	ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 	Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+	OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+	StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 	UseVIPFailover       bool                         `mapconv:"Status.UseVIPFailover"`
 	Region               types.EProxyLBRegion         `mapconv:"Status.Region"`
 	Name                 string
@@ -22270,6 +22354,8 @@ func (o *ProxyLBCreateRequest) setDefaults() interface{} {
 		MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 		ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 		Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+		OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+		StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 		UseVIPFailover       bool                         `mapconv:"Status.UseVIPFailover"`
 		Region               types.EProxyLBRegion         `mapconv:"Status.Region"`
 		Name                 string
@@ -22292,6 +22378,8 @@ func (o *ProxyLBCreateRequest) setDefaults() interface{} {
 		MonitoringSuiteLog:   o.GetMonitoringSuiteLog(),
 		ProxyProtocol:        o.GetProxyProtocol(),
 		Syslog:               o.GetSyslog(),
+		OriginGuard:          o.GetOriginGuard(),
+		StrictRule:           o.GetStrictRule(),
 		UseVIPFailover:       o.GetUseVIPFailover(),
 		Region:               o.GetRegion(),
 		Name:                 o.GetName(),
@@ -22442,6 +22530,26 @@ func (o *ProxyLBCreateRequest) SetSyslog(v *ProxyLBSyslog) {
 	o.Syslog = v
 }
 
+// GetOriginGuard returns value of OriginGuard
+func (o *ProxyLBCreateRequest) GetOriginGuard() *ProxyLBOriginGuard {
+	return o.OriginGuard
+}
+
+// SetOriginGuard sets value to OriginGuard
+func (o *ProxyLBCreateRequest) SetOriginGuard(v *ProxyLBOriginGuard) {
+	o.OriginGuard = v
+}
+
+// GetStrictRule returns value of StrictRule
+func (o *ProxyLBCreateRequest) GetStrictRule() *ProxyLBStrictRule {
+	return o.StrictRule
+}
+
+// SetStrictRule sets value to StrictRule
+func (o *ProxyLBCreateRequest) SetStrictRule(v *ProxyLBStrictRule) {
+	o.StrictRule = v
+}
+
 // GetUseVIPFailover returns value of UseVIPFailover
 func (o *ProxyLBCreateRequest) GetUseVIPFailover() bool {
 	return o.UseVIPFailover
@@ -22541,6 +22649,8 @@ type ProxyLBUpdateRequest struct {
 	MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 	ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 	Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+	OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+	StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 	SettingsHash         string                       `json:",omitempty" mapconv:",omitempty"`
 	Name                 string
 	Description          string
@@ -22564,6 +22674,8 @@ func (o *ProxyLBUpdateRequest) setDefaults() interface{} {
 		MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 		ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 		Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+		OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+		StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 		SettingsHash         string                       `json:",omitempty" mapconv:",omitempty"`
 		Name                 string
 		Description          string
@@ -22583,6 +22695,8 @@ func (o *ProxyLBUpdateRequest) setDefaults() interface{} {
 		MonitoringSuiteLog:   o.GetMonitoringSuiteLog(),
 		ProxyProtocol:        o.GetProxyProtocol(),
 		Syslog:               o.GetSyslog(),
+		OriginGuard:          o.GetOriginGuard(),
+		StrictRule:           o.GetStrictRule(),
 		SettingsHash:         o.GetSettingsHash(),
 		Name:                 o.GetName(),
 		Description:          o.GetDescription(),
@@ -22721,6 +22835,26 @@ func (o *ProxyLBUpdateRequest) SetSyslog(v *ProxyLBSyslog) {
 	o.Syslog = v
 }
 
+// GetOriginGuard returns value of OriginGuard
+func (o *ProxyLBUpdateRequest) GetOriginGuard() *ProxyLBOriginGuard {
+	return o.OriginGuard
+}
+
+// SetOriginGuard sets value to OriginGuard
+func (o *ProxyLBUpdateRequest) SetOriginGuard(v *ProxyLBOriginGuard) {
+	o.OriginGuard = v
+}
+
+// GetStrictRule returns value of StrictRule
+func (o *ProxyLBUpdateRequest) GetStrictRule() *ProxyLBStrictRule {
+	return o.StrictRule
+}
+
+// SetStrictRule sets value to StrictRule
+func (o *ProxyLBUpdateRequest) SetStrictRule(v *ProxyLBStrictRule) {
+	o.StrictRule = v
+}
+
 // GetSettingsHash returns value of SettingsHash
 func (o *ProxyLBUpdateRequest) GetSettingsHash() string {
 	return o.SettingsHash
@@ -22810,6 +22944,8 @@ type ProxyLBUpdateSettingsRequest struct {
 	MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 	ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 	Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+	OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+	StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 	SettingsHash         string                       `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -22829,6 +22965,8 @@ func (o *ProxyLBUpdateSettingsRequest) setDefaults() interface{} {
 		MonitoringSuiteLog   *MonitoringSuiteLog          `mapconv:"Settings.ProxyLB.MonitoringSuiteLog,recursive"`
 		ProxyProtocol        *ProxyLBProxyProtocol        `mapconv:"Settings.ProxyLB.ProxyProtocol,recursive"`
 		Syslog               *ProxyLBSyslog               `mapconv:"Settings.ProxyLB.Syslog,recursive"`
+		OriginGuard          *ProxyLBOriginGuard          `mapconv:"Settings.ProxyLB.OriginGuard,recursive"`
+		StrictRule           *ProxyLBStrictRule           `mapconv:"Settings.ProxyLB.StrictRule,recursive"`
 		SettingsHash         string                       `json:",omitempty" mapconv:",omitempty"`
 	}{
 		HealthCheck:          o.GetHealthCheck(),
@@ -22844,6 +22982,8 @@ func (o *ProxyLBUpdateSettingsRequest) setDefaults() interface{} {
 		MonitoringSuiteLog:   o.GetMonitoringSuiteLog(),
 		ProxyProtocol:        o.GetProxyProtocol(),
 		Syslog:               o.GetSyslog(),
+		OriginGuard:          o.GetOriginGuard(),
+		StrictRule:           o.GetStrictRule(),
 		SettingsHash:         o.GetSettingsHash(),
 	}
 }
@@ -22976,6 +23116,26 @@ func (o *ProxyLBUpdateSettingsRequest) GetSyslog() *ProxyLBSyslog {
 // SetSyslog sets value to Syslog
 func (o *ProxyLBUpdateSettingsRequest) SetSyslog(v *ProxyLBSyslog) {
 	o.Syslog = v
+}
+
+// GetOriginGuard returns value of OriginGuard
+func (o *ProxyLBUpdateSettingsRequest) GetOriginGuard() *ProxyLBOriginGuard {
+	return o.OriginGuard
+}
+
+// SetOriginGuard sets value to OriginGuard
+func (o *ProxyLBUpdateSettingsRequest) SetOriginGuard(v *ProxyLBOriginGuard) {
+	o.OriginGuard = v
+}
+
+// GetStrictRule returns value of StrictRule
+func (o *ProxyLBUpdateSettingsRequest) GetStrictRule() *ProxyLBStrictRule {
+	return o.StrictRule
+}
+
+// SetStrictRule sets value to StrictRule
+func (o *ProxyLBUpdateSettingsRequest) SetStrictRule(v *ProxyLBStrictRule) {
+	o.StrictRule = v
 }
 
 // GetSettingsHash returns value of SettingsHash


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

エンハンスドロードバランサ（ProxyLB）に以下の2フィールドを追加しました：

- `OriginGuard`: トークンを用いてOrigin Guardを有効化/無効化する設定
- `StrictRule`: ストリクトルールの有効化設定

### ドキュメントの変更は必要ですか？

不要