### PR TITLE
ci: add trace/otel to dependabot gomod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
       time: "00:00"
     commit-message:
       prefix: "go:"
+
+  - package-ecosystem: gomod
+    directory: /trace/otel
+    schedule:
+      interval: daily
+      time: "00:00"
+    commit-message:
+      prefix: "go:"


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

trace/otel 配下の go.mod も dependabot で自動更新チェックの対象に追加した。

### ドキュメントの変更は必要ですか？

不要