### PR TITLE
deprecate: ContainerRegistry public access settings

### DIFF
--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -2088,6 +2088,7 @@ func (f *fieldsDef) ContainerRegistryFQDN() *dsl.FieldDesc {
 
 func (f *fieldsDef) ContainerRegistryAccessLevel() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
+		// Deprecated: コンテナレジストリの公開設定（Pullのみ）は廃止予定です。今後は一律「非公開」での運用となります。
 		Name: "AccessLevel",
 		Type: meta.Static(types.EContainerRegistryAccessLevel("")),
 		Tags: &dsl.FieldTags{

--- a/naked/container_registry.go
+++ b/naked/container_registry.go
@@ -50,6 +50,7 @@ type ContainerRegistrySettings struct {
 
 // ContainerRegistrySetting セッティング
 type ContainerRegistrySetting struct {
+	// Deprecated: コンテナレジストリの公開設定（Pullのみ）は廃止予定です。今後は一律「非公開」での運用となります。
 	Public        types.EContainerRegistryAccessLevel `json:"public" yaml:"public"` // readwrite or readonly or none
 	VirtualDomain string                              `json:"virtual_domain" yaml:"virtual_domain"`
 }

--- a/types/container_registry_access_level.go
+++ b/types/container_registry_access_level.go
@@ -15,6 +15,8 @@
 package types
 
 // EContainerRegistryAccessLevel コンテナレジストリへアクセスレベル
+//
+// Deprecated: コンテナレジストリの公開設定（Pullのみ）は廃止予定です。今後は一律「非公開」での運用となります。
 type EContainerRegistryAccessLevel string
 
 // String EContainerRegistryVisibilityの文字列表現
@@ -24,6 +26,7 @@ func (v EContainerRegistryAccessLevel) String() string {
 
 // ContainerRegistryAccessLevels コンテナレジストリのアクセス範囲
 var ContainerRegistryAccessLevels = struct {
+	// Deprecated: コンテナレジストリの公開設定（Pullのみ）は廃止予定です。今後は一律「非公開」での運用となります。
 	ReadOnly EContainerRegistryAccessLevel
 	None     EContainerRegistryAccessLevel
 }{


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

コンテナレジストリの公開設定（Pullのみ）が廃止予定であることを
`Deprecated` コメントとして型・定数・フィールド・DSL定義に追加した。

- `types.EContainerRegistryAccessLevel`
- `types.ContainerRegistryAccessLevels.ReadOnly`
- `naked.ContainerRegistrySetting.Public`
- `internal/define/fields.go` の `ContainerRegistryAccessLevel()`

### ドキュメントの変更は必要ですか？

不要